### PR TITLE
SysKit changes for non interactive extraction process

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
@@ -31,7 +31,7 @@ function Get-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    # Add-O365DSCTelemetryEvent -Data $data
     #endregion
     try
     {
@@ -104,7 +104,7 @@ function Set-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    #Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
@@ -192,7 +192,7 @@ function Export-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    # Add-O365DSCTelemetryEvent -Data $data
     #endregion
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
         -Platform PnP
@@ -216,7 +216,7 @@ function Export-TargetResource
     $i = 1
     foreach ($batch in $instances)
     {
-        Start-Job -Name "SPOPropertyBag$i" -ScriptBlock {
+        Start-DSCInitializedJob -Name "SPOPropertyBag$i" -ScriptBlock {
             Param(
                 [Parameter(Mandatory = $true)]
                 [System.Object[]]
@@ -273,7 +273,7 @@ function Export-TargetResource
 
                                 $CurrentModulePath = $params.ScriptRoot + "\MSFT_SPOPropertyBag.psm1"
                                 Import-Module $CurrentModulePath -Force | Out-Null
-                                Import-Module ($params.ScriptRoot + "\..\..\Modules\O365DSCTelemetryEngine.psm1") -Force | Out-Null
+                                # Import-Module ($params.ScriptRoot + "\..\..\Modules\O365DSCTelemetryEngine.psm1") -Force | Out-Null
                                 $result = Get-TargetResource @getValues
                                 $result.Value = [System.String]$result.Value
                                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -8,7 +8,8 @@ function Get-TargetResource
         [System.String]
         $Url,
 
-        [Parameter(Mandatory = $true)]
+        # Some site collections do not have a title, so we set mandatory to false
+        [Parameter(Mandatory = $false)]
         [System.String]
         $Title,
 

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.schema.mof
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SPOSite : OMI_BaseResource
 {
     [Key, Description("The URL of the site collection.")] string Url;
-    [Required, Description("The title of the site collection.")] string Title;
+    [Write, Description("The title of the site collection.")] string Title;
     [Required, Description("TimeZone ID of the site collection.")] uint32 TimeZoneId;
     [Required, Description("Specifies with template of site to create.")] string Template;
     [Write, Description("The URL of the Hub site the site collection needs to get connected to.")] string HubUrl;
@@ -18,6 +18,8 @@ class MSFT_SPOSite : OMI_BaseResource
     [Write, Description("Disables App Views."), ValueMap{"Unknown", "Disabled", "NotDisabled"}, Values{"Unknown", "Disabled", "NotDisabled"}] string DisableAppViews;
     [Write, Description("Disables Company wide sharing links."), ValueMap{"Unknown", "Disabled", "NotDisabled"}, Values{"Unknown", "Disabled", "NotDisabled"}] string DisableCompanyWideSharingLinks;
     [Write, Description("Specifies the language of the new site collection. Defaults to the current language of the web connected to.")] uint32 LocaleId;
-    [Write, Description("Present ensures the site collection exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Defines geo-restriction settings for this site"), ValueMap{"NoRestriction", "BlockMoveOnly", "BlockFull", "Unknown"}, Values{"NoRestriction", "BlockMoveOnly", "BlockFull", "Unknown"}] string RestrictedToGeo;
+    [Write, Description("Disables or enables the Social Bar for Site Collection.")] boolean SocialBarOnSitePagesDisabled;
+    [Write, Description("Present ensures the site collection exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;    
     [Required, Description("Credentials of the SharePoint Global Admin"), EmbeddedInstance("MSFT_Credential")] string GlobalAdminAccount;
 };

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -27,7 +27,7 @@ function Get-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    # Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
@@ -102,7 +102,7 @@ function Set-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    # Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
@@ -185,7 +185,7 @@ function Export-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    # Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     Test-MSCloudLogin -Platform AzureAD -O365Credential $GlobalAdminAccount
@@ -211,7 +211,7 @@ function Export-TargetResource
     $i = 1
     foreach ($batch in $instances)
     {
-        Start-Job -Name "SPOUserProfileProperty$i" -ScriptBlock {
+        Start-DSCInitializedJob -Name "SPOUserProfileProperty$i" -ScriptBlock {
             Param(
                 [Parameter(Mandatory = $true)]
                 [System.Object[]]
@@ -253,7 +253,7 @@ function Export-TargetResource
                         if ($result.Ensure -eq "Present")
                         {
                             Import-Module ($params.ScriptRoot + "\..\..\Modules\Office365DSCUtil.psm1") -Force | Out-Null
-                            Import-Module ($params.ScriptRoot + "\..\..\Modules\O365DSCTelemetryEngine.psm1") -Force | Out-Null
+                            # Import-Module ($params.ScriptRoot + "\..\..\Modules\O365DSCTelemetryEngine.psm1") -Force | Out-Null
 
                             $result.Properties = ConvertTo-SPOUserProfilePropertyInstanceString -Properties $result.Properties
                             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    #Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     try
@@ -120,7 +120,7 @@ function Set-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    #Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
@@ -226,7 +226,7 @@ function Export-TargetResource
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
-    Add-O365DSCTelemetryEvent -Data $data
+    #Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
     $result = ""
@@ -250,7 +250,7 @@ function Export-TargetResource
     $i = 1
     foreach ($batch in $instances)
     {
-        Start-Job -Name "TeamsUser$i" -ScriptBlock {
+        Start-DSCInitializedJob -Name "TeamsUser$i" -ScriptBlock {
             Param(
                 [Parameter(Mandatory = $true)]
                 [System.Object[]]

--- a/Modules/Office365DSC/Modules/O365DSCTelemetryEngine.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCTelemetryEngine.psm1
@@ -38,6 +38,10 @@ function Add-O365DSCTelemetryEvent
         $Metrics
     )
 
+    # in SysKit we do not want to send any telemetry
+    # at least not to the default Office365DSC project
+	return
+
     $TelemetryEnabled = [System.Environment]::GetEnvironmentVariable('O365DSCTelemetryEnabled', `
         [System.EnvironmentVariableTarget]::Machine)
     if ($null -eq $TelemetryEnabled -or $TelemetryEnabled -eq $true)

--- a/Modules/Office365DSC/Office365DSC.psd1
+++ b/Modules/Office365DSC/Office365DSC.psd1
@@ -70,15 +70,21 @@
         @{
             ModuleName      = "AzureAD"
             RequiredVersion = "2.0.2.4"
-        },
-        @{
-            ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.0.0"
-        },
-        @{
-            ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
-            RequiredVersion = "2.0.37"
         }
+        # In SysKit Trace, we provide our own version of MSCloudLoginAssistant
+        # so no need to list it as a dependency
+        # ,
+        # @{
+        #     ModuleName      = "MSCloudLoginAssistant"
+        #     RequiredVersion = "1.0.0"
+        # },
+        # we do not want to immediatelly load powerapp admin module because it uses an old ADAL version
+        # and it messes up everything when office365 dsc is loaded
+        # ,
+        # @{
+        #     ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
+        #     RequiredVersion = "2.0.37"
+        # }
     )
 
     # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION

- Not sure why, but on my system the Add-O365DSCTelemetryEvent is causing nothing but problems. This is why i commented it on the resources where the extraction happens in a job.
- fixed the SPOSite resource so that it loads, but did not go forward with other changes because Nik will probably be fixing this
- added a Start-DSCInitializedJob function to be used instead of Start-Job so that the application identity and delegation is used in the new powershell processes that are spawned with start-job
- removed the mscloud login assistent from the required modules because we are bringing our own implementation
- removed the powerapps administration because it cause problems with the older version of ADAL being loaded in the appdomain