### PR TITLE
Preference and error handling

### DIFF
--- a/Modules/Office365DSC/Modules/O365DSCLogEngine.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCLogEngine.psm1
@@ -22,8 +22,8 @@ function New-Office365DSCLogEntry
 
     try
     {
-        $VerbosePreference = 'Continue'
         Write-Verbose -Message "Logging a new Error"
+        Write-Error  -ErrorRecord $Error
 
         #region Telemetry
         $driftedData = [System.Collections.Generic.Dictionary[[String], [String]]]::new()

--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -42,8 +42,14 @@ function Start-O365ConfigurationExtract
     )
 
     $InformationPreference = "Continue"
-    $VerbosePreference = "SilentlyContinue"
-    $WarningPreference = "SilentlyContinue"
+
+    $DefaultWarningPreference = $WarningPreference
+    $DefaultVerbosePreference = $VerbosePreference
+
+    # We will set this on our own in app, it is already on SiletntlyContinue by default,
+    # but we dont want it here explicitly overriding the variable
+    # $VerbosePreference = "SilentlyContinue"
+    # $WarningPreference = "SilentlyContinue"
 
     $organization = ""
     $principal = "" # Principal represents the "NetBios" name of the tenant (e.g. the O365DSC part of O365DSC.onmicrosoft.com)
@@ -181,6 +187,11 @@ function Start-O365ConfigurationExtract
         catch
         {
             New-Office365DSCLogEntry -Error $_ -Message $ResourceModule.Name -Source "[O365DSCReverse]$($ResourceModule.Name)"
+        }
+        finally
+        {
+            $WarningPreference = $DefaultWarningPreference;
+            $VerbosePreference = $DefaultVerbosePreference;
         }
     }
 


### PR DESCRIPTION
This is a part of error handling changes and verbose logging.

This ensures that we can control verbose and warning preference from outside of DSC script.

Also added error writing to output that will go to error stream.