### PR TITLE
Feat/early resource platform fail

### DIFF
--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -110,6 +110,7 @@ function Start-O365ConfigurationExtract
         -Resolve
     $AllResources = Get-ChildItem $ResourcesPath -Recurse | Where-Object { $_.Name -like 'MSFT_*.psm1' }
 
+    $platformSkipsNotified = @()
     foreach ($ResourceModule in $AllResources)
     {
         try
@@ -177,6 +178,12 @@ function Start-O365ConfigurationExtract
                     }
                     $isAvailable = Check-PlatformAvailability -Platform $platform
                     $shouldSkip = $shouldSkip -or !$isAvailable
+
+                    if(!$isAvailable -and !$platformSkipsNotified.Contains($platform))
+                    {
+                        Write-Error "The [$platform] connection has failed and all of the related resources will be skipped to avoid unnecessary errors."
+                        $platformSkipsNotified += $platform
+                    }
                 }
 
                 if($shouldSkip)

--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -159,7 +159,6 @@ function Start-O365ConfigurationExtract
                     break
                 }
             }
-
             if (($null -ne $ComponentsToExtract -and
                     $ComponentsToExtract.Contains("chck" + $resourceName)) -or
                 $AllComponents -or ($null -ne $Workloads -and $Workloads.Contains($currentWorkload)))

--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -164,10 +164,9 @@ function Start-O365ConfigurationExtract
                     $ComponentsToExtract.Contains("chck" + $resourceName)) -or
                 $AllComponents -or ($null -ne $Workloads -and $Workloads.Contains($currentWorkload)))
             {
-
+                $shouldSkip = $false
                 $usedPlatforms = Get-ResourcePlatformUsage -Resource $resourceName -ResourceModuleFilePath $ResourceModule.FullName
 
-                $shouldSkip = $false
                 foreach($platform in $usedPlatforms)
                 {
                     # we will skip PnP if there was a problem connecting to a specific site
@@ -186,7 +185,6 @@ function Start-O365ConfigurationExtract
                     Write-Verbose "Skipped [$resourceName] because of connection problems with the used MsCloudLogin platform"
                     continue;
                 }
-
 
                 Import-Module $ResourceModule.FullName | Out-Null
                 Write-Information "Extracting [$resourceName]..."
@@ -313,7 +311,6 @@ function Start-O365ConfigurationExtract
     }
 }
 
-
 function Check-PlatformAvailability
 {
     [CmdletBinding()]
@@ -328,7 +325,6 @@ function Check-PlatformAvailability
     return $null -eq $faulted -or $faulted -eq $false
 }
 
-
 function Get-ResourcePlatformUsage
 {
     [CmdletBinding()]
@@ -341,10 +337,9 @@ function Get-ResourcePlatformUsage
         [string]
         $ResourceModuleFilePath
     )
-
     $fileContent = Get-Content $ResourceModuleFilePath -Raw
-
     $matches = [Regex]::Matches($fileContent, '-Platform\s+(?<platform>\w+)', [ System.Text.RegularExpressions.RegexOptions]::IgnoreCase);
+
     $platforms = @()
     foreach($match in $matches)
     {


### PR DESCRIPTION
This uses the connection tracking functionality in the MSCloudLoginAssistant to skip a resource if it's obvious from the platform connection that it will fail. PnP is a special case. In PnP the check occurs only if we are connected to the central admin url because it may be a permission issue. Although there actually should be no permissions issue since we are dealing with application permisssions.