### PR TITLE
Fix for extracting all users and groups

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -358,7 +358,7 @@ function Export-TargetResource
     $content = ''
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
         -Platform AzureAD
-    $groups = Get-AzureADGroup | Where-Object -FilterScript {
+    $groups = Get-AzureADGroup -All $true | Where-Object -FilterScript {
         $_.MailNickName -ne "00000000-0000-0000-0000-000000000000"
     }
 

--- a/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -574,7 +574,7 @@ function Export-TargetResource
             $principal = $organization.Split(".")[0]
         }
     }
-    $users = Get-AzureADUser
+    $users = Get-AzureADUser -All $true
     $content = ''
     $partialContent = ""
     $i = 1


### PR DESCRIPTION
Added All parameters to PowerShell cmdlets that fetch AD Users and Groups. Without this parameter, only the first 100 were extracted.