### PR TITLE
Teams throttling handling V1

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -141,6 +141,10 @@ function Get-TargetResource
         GlobalAdminAccount           = $GlobalAdminAccount
     }
 
+    if ($null -eq (Get-Command 'Get-AddressList' -ErrorAction SilentlyContinue))
+    {
+        return $nullReturn
+    }
     $AddressLists = Get-AddressList
     $AddressList = $AddressLists | Where-Object -FilterScript { $_.Name -eq $Name }
 
@@ -529,17 +533,20 @@ function Export-TargetResource
         $GlobalAdminAccount
     )
     $InformationPreference = 'Continue'
-    
+
     #region Telemetry
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add("Resource", $MyInvocation.MyCommand.ModuleName)
     $data.Add("Method", $MyInvocation.MyCommand)
     Add-O365DSCTelemetryEvent -Data $data
     #endregion
-    
+
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
         -Platform ExchangeOnline
-
+    if ($null -eq (Get-Command 'Get-AddressList' -ErrorAction SilentlyContinue))
+    {
+        return ""
+    }
     $dscContent = ""
     $i = 1
     [array]$addressLists = Get-Addresslist

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
@@ -24,7 +24,10 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        $GlobalAdminAccount
+        $GlobalAdminAccount,
+
+        [Parameter()]
+        $RawInputObject
     )
 
     Write-Verbose -Message "Getting Management Role configuration for $Name"
@@ -38,9 +41,15 @@ function Get-TargetResource
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
         -Platform ExchangeOnline
 
-    $AllManagementRoles = Get-ManagementRole
-
-    $ManagementRole = $AllManagementRoles | Where-Object -FilterScript { $_.Name -eq $Name }
+    if($RawInputObject)
+    {
+        $ManagementRole = $RawInputObject
+    }
+    else
+    {
+        $AllManagementRoles = Get-ManagementRole
+        $ManagementRole = $AllManagementRoles | Where-Object -FilterScript { $_.Name -eq $Name }
+    }
 
     if ($null -eq $ManagementRole)
     {
@@ -225,6 +234,7 @@ function Export-TargetResource
         $Params = @{
             Name               = $ManagementRole.Name
             GlobalAdminAccount = $GlobalAdminAccount
+            RawInputObject     = $ManagementRole
         }
         $result = Get-TargetResource @Params
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
@@ -36,7 +36,6 @@ function Get-TargetResource
 
     $nullReturn = @{
         Identity  = ""
-        Path      = $null
         Publish   = $Publish
         Overwrite = $Overwrite
         Ensure    = "Absent"
@@ -233,6 +232,11 @@ function Export-TargetResource
                     Identity           = $identity
                 }
                 $result = Get-TargetResource @params
+                if($result.Ensure -eq "Absent")
+                {
+                    continue
+                }
+
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        SPOApp " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -281,17 +281,20 @@ function Export-TargetResource
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
         -Platform MicrosoftTeams
 
-    $teams = Get-Team
+    [array]$teams = Get-AllTeamsCached
     $j = 1
     $content = ''
     foreach ($team in $Teams)
     {
-        $channels = Get-TeamChannel -GroupId $team.GroupId
+        $channels = [System.Collections.ArrayList]:: new()
+        Invoke-With429Retry -ScriptBlock {
+            $channels.AddRange([array](Get-TeamChannel -GroupId $team.GroupId))
+        }
         $i = 1
         Write-Information "    > [$j/$($Teams.Length)] Team {$($team.DisplayName)}"
         foreach ($channel in $channels)
         {
-            Write-Information "        - [$i/$($channels.Length)] $($channel.DisplayName)"
+            Write-Information "        - [$i/$($channels.Count)] $($channel.DisplayName)"
             $params = @{
                 TeamName           = $team.DisplayName
                 TeamMailNickName   = $team.MailNickName

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -287,7 +287,7 @@ function Export-TargetResource
     foreach ($team in $Teams)
     {
         $channels = [System.Collections.ArrayList]:: new()
-        Invoke-With429Retry -ScriptBlock {
+        Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
             $channels.AddRange([array](Get-TeamChannel -GroupId $team.GroupId))
         }
         $i = 1

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -186,7 +186,11 @@ function Get-TargetResource
             }
         }
 
-        $Owners = Get-TeamUser -GroupId $team.GroupId -Role Owner
+        $Owners = [System.Collections.ArrayList]:: new()
+        Invoke-With429Retry -ScriptBlock {
+            $Owners.AddRange([array](Get-TeamUser -GroupId $team.GroupId -Role Owner))
+        }
+
         $OwnersArray = @()
         if ($null -ne $Owners)
         {
@@ -550,7 +554,7 @@ function Export-TargetResource
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
         -Platform MicrosoftTeams
 
-    $teams = Get-Team
+    $teams = Get-AllTeamsCached
     $i = 1
     $content = ""
     $organization = $GlobalAdminAccount.UserName.Split('@')[1]

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -187,7 +187,7 @@ function Get-TargetResource
         }
 
         $Owners = [System.Collections.ArrayList]:: new()
-        Invoke-With429Retry -ScriptBlock {
+        Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
             $Owners.AddRange([array](Get-TeamUser -GroupId $team.GroupId -Role Owner))
         }
 

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -313,7 +313,7 @@ function Export-TargetResource
                         try
                         {
                             $users = [System.Collections.ArrayList]:: new()
-                            Invoke-With429Retry -ScriptBlock {
+                            Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
                                 $users.AddRange([array](Get-TeamUser -GroupId $team.GroupId))
                             }
 

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -250,7 +250,7 @@ function Export-TargetResource
 
     # Get all Site Collections in tenant;
     Test-MSCloudLogin -Platform MicrosoftTeams -CloudCredential $GlobalAdminAccount
-    [array]$instances = Get-Team
+    [array]$instances = Get-AllTeamsCached
     if ($instances.Length -ge $MaxProcesses)
     {
         [array]$instances = Split-ArrayByParts -Array $instances -Parts $MaxProcesses
@@ -312,7 +312,11 @@ function Export-TargetResource
                     {
                         try
                         {
-                            $users = Get-TeamUser -GroupId $team.GroupId
+                            $users = [System.Collections.ArrayList]:: new()
+                            Invoke-With429Retry -ScriptBlock {
+                                $users.AddRange([array](Get-TeamUser -GroupId $team.GroupId))
+                            }
+
                             $i = 1
                             $totalCount = $item.Count
                             if ($null -eq $totalCount)
@@ -322,7 +326,7 @@ function Export-TargetResource
                             Write-Information "    > [$j/$totalCount] Team {$($team.DisplayName)}"
                             foreach ($user in $users)
                             {
-                                Write-Information "        - [$i/$($users.Length)] $($user.User)"
+                                Write-Information "        - [$i/$($users.Count)] $($user.User)"
                                 $getParams = @{
                                     TeamName           = $team.DisplayName
                                     TeamMailNickName   = $team.MailNickName

--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -46,6 +46,8 @@ function Start-O365ConfigurationExtract
     $DefaultWarningPreference = $WarningPreference
     $DefaultVerbosePreference = $VerbosePreference
 
+    Reset-AllTeamsCached
+
     # We will set this on our own in app, it is already on SiletntlyContinue by default,
     # but we dont want it here explicitly overriding the variable
     # $VerbosePreference = "SilentlyContinue"

--- a/Modules/Office365DSC/Modules/O365DSCReverseGUI.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverseGUI.psm1
@@ -834,7 +834,7 @@ function Show-O365GUI
         $chckTeamsCallRoutingPolicy = New-Object System.Windows.Forms.CheckBox
         $chckTeamsCallRoutingPolicy.Top = 100
         $chckTeamsCallRoutingPolicy.AutoSize = $true;
-        $chckTeamsCallRoutingPolicy.Name = "chckTeamsCallRoutingPolicy"
+        $chckTeamsCallRoutingPolicy.Name = "chckTeamsEmergencyCallRoutingPolicy"
         $chckTeamsCallRoutingPolicy.Checked = $true
         $chckTeamsCallRoutingPolicy.Text = "Emergency Call Routing Policies"
         $pnlTeams.Controls.Add($chckTeamsCallRoutingPolicy)

--- a/Modules/Office365DSC/Modules/O365DSCReverseGUI.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverseGUI.psm1
@@ -66,7 +66,7 @@ function Show-O365GUI
         $pnlExo = New-Object System.Windows.Forms.Panel
         $pnlExo.Top = 88 + $topBannerHeight
         $pnlExo.Left = $firstColumnLeft
-        $pnlExo.Height = 780
+        $pnlExo.Height = 860
         $pnlExo.Width = 300
         $pnlExo.BorderStyle = [System.Windows.Forms.BorderStyle]::FixedSingle
 
@@ -94,8 +94,24 @@ function Show-O365GUI
         $chckEXOAddressBookPolicy.Text = "Address Book Policy"
         $pnlExo.Controls.Add($chckEXOAddressBookPolicy)
 
+        $chckEXOAddressList = New-Object System.Windows.Forms.CheckBox
+        $chckEXOAddressList.Top = 60
+        $chckEXOAddressList.AutoSize = $true;
+        $chckEXOAddressList.Name = "chckEXOAddressList"
+        $chckEXOAddressList.Checked = $true
+        $chckEXOAddressList.Text = "Address Lists"
+        $pnlExo.Controls.Add($chckEXOAddressList)
+
+        $chckEXOAtpPolicyForO365 = New-Object System.Windows.Forms.CheckBox
+        $chckEXOAtpPolicyForO365.Top = 80
+        $chckEXOAtpPolicyForO365.AutoSize = $true;
+        $chckEXOAtpPolicyForO365.Name = "chckEXOAtpPolicyForO365"
+        $chckEXOAtpPolicyForO365.Checked = $true
+        $chckEXOAtpPolicyForO365.Text = "Advanced Threat Protection Policies"
+        $pnlExo.Controls.Add($chckEXOAtpPolicyForO365)
+
         $chckEXOAntiPhishPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOAntiPhishPolicy.Top = 60
+        $chckEXOAntiPhishPolicy.Top = 100
         $chckEXOAntiPhishPolicy.AutoSize = $true;
         $chckEXOAntiPhishPolicy.Name = "chckEXOAntiPhishPolicy"
         $chckEXOAntiPhishPolicy.Checked = $true
@@ -103,31 +119,31 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOAntiPhishPolicy)
 
         $chckEXOAntiPhishRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOAntiPhishRule.Top = 80
+        $chckEXOAntiPhishRule.Top = 120
         $chckEXOAntiPhishRule.AutoSize = $true;
         $chckEXOAntiPhishRule.Name = "chckEXOAntiPhishRule"
         $chckEXOAntiPhishRule.Checked = $true
         $chckEXOAntiPhishRule.Text = "Anti-Phish Rules"
         $pnlExo.Controls.Add($chckEXOAntiPhishRule)
 
-        $chckEXOAtpPolicyForO365 = New-Object System.Windows.Forms.CheckBox
-        $chckEXOAtpPolicyForO365.Top = 100
-        $chckEXOAtpPolicyForO365.AutoSize = $true;
-        $chckEXOAtpPolicyForO365.Name = "chckEXOAtpPolicyForO365"
-        $chckEXOAtpPolicyForO365.Checked = $true
-        $chckEXOAtpPolicyForO365.Text = "Advanced Threat Protection Policies"
-        $pnlExo.Controls.Add($chckEXOAtpPolicyForO365)
-
         $chckEXOApplicationAccessPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOApplicationAccessPolicy.Top = 120
+        $chckEXOApplicationAccessPolicy.Top = 140
         $chckEXOApplicationAccessPolicy.AutoSize = $true;
         $chckEXOApplicationAccessPolicy.Name = "chckEXOApplicationAccessPolicy"
         $chckEXOApplicationAccessPolicy.Checked = $true
         $chckEXOApplicationAccessPolicy.Text = "Application Access Policies"
         $pnlExo.Controls.Add($chckEXOApplicationAccessPolicy)
 
+        $chckEXOAvailabilityAddressSpace = New-Object System.Windows.Forms.CheckBox
+        $chckEXOAvailabilityAddressSpace.Top = 160
+        $chckEXOAvailabilityAddressSpace.AutoSize = $true;
+        $chckEXOAvailabilityAddressSpace.Name = "chckEXOAvailabilityAddressSpace"
+        $chckEXOAvailabilityAddressSpace.Checked = $true
+        $chckEXOAvailabilityAddressSpace.Text = "Availability Address Spaces"
+        $pnlExo.Controls.Add($chckEXOAvailabilityAddressSpace)
+
         $chckEXOAvailabilityConfig = New-Object System.Windows.Forms.CheckBox
-        $chckEXOAvailabilityConfig.Top = 140
+        $chckEXOAvailabilityConfig.Top = 180
         $chckEXOAvailabilityConfig.AutoSize = $true;
         $chckEXOAvailabilityConfig.Name = "chckEXOAvailabilityConfig"
         $chckEXOAvailabilityConfig.Checked = $true
@@ -135,7 +151,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOAvailabilityConfig)
 
         $chckEXOClientAccessRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOClientAccessRule.Top = 160
+        $chckEXOClientAccessRule.Top = 200
         $chckEXOClientAccessRule.AutoSize = $true;
         $chckEXOClientAccessRule.Name = "chckEXOClientAccessRule"
         $chckEXOClientAccessRule.Checked = $true
@@ -143,7 +159,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOClientAccessRule)
 
         $chckEXOCASMailboxPlan = New-Object System.Windows.Forms.CheckBox
-        $chckEXOCASMailboxPlan.Top = 180
+        $chckEXOCASMailboxPlan.Top = 220
         $chckEXOCASMailboxPlan.AutoSize = $true;
         $chckEXOCASMailboxPlan.Name = "chckEXOCASMailboxPlan"
         $chckEXOCASMailboxPlan.Checked = $true
@@ -151,7 +167,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOCASMailboxPlan)
 
         $chckEXODkimSigningConfig = New-Object System.Windows.Forms.CheckBox
-        $chckEXODkimSigningConfig.Top = 200
+        $chckEXODkimSigningConfig.Top = 240
         $chckEXODkimSigningConfig.AutoSize = $true;
         $chckEXODkimSigningConfig.Name = "chckEXODkimSigningConfig"
         $chckEXODkimSigningConfig.Checked = $true
@@ -159,7 +175,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXODkimSigningConfig)
 
         $chckEXOEmailAddressPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOEmailAddressPolicy.Top = 220
+        $chckEXOEmailAddressPolicy.Top = 260
         $chckEXOEmailAddressPolicy.AutoSize = $true;
         $chckEXOEmailAddressPolicy.Name = "chckEXOEmailAddressPolicy"
         $chckEXOEmailAddressPolicy.Checked = $true
@@ -167,15 +183,15 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOEmailAddressPolicy)
 
         $chckEXOGlobalAddressList = New-Object System.Windows.Forms.CheckBox
-        $chckEXOGlobalAddressList.Top = 240
+        $chckEXOGlobalAddressList.Top = 280
         $chckEXOGlobalAddressList.AutoSize = $true;
         $chckEXOGlobalAddressList.Name = "chckEXOGlobalAddressList"
         $chckEXOGlobalAddressList.Checked = $true
-        $chckEXOGlobalAddressList.Text = "Global Address List"
+        $chckEXOGlobalAddressList.Text = "Global Address Lists"
         $pnlExo.Controls.Add($chckEXOGlobalAddressList)
 
         $chckEXOHostedConnectionFilterPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOHostedConnectionFilterPolicy.Top = 260
+        $chckEXOHostedConnectionFilterPolicy.Top = 300
         $chckEXOHostedConnectionFilterPolicy.AutoSize = $true;
         $chckEXOHostedConnectionFilterPolicy.Name = "chckEXOHostedConnectionFilterPolicy"
         $chckEXOHostedConnectionFilterPolicy.Checked = $true
@@ -183,7 +199,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOHostedConnectionFilterPolicy)
 
         $chckEXOHostedContentFilterPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOHostedContentFilterPolicy.Top = 280
+        $chckEXOHostedContentFilterPolicy.Top = 320
         $chckEXOHostedContentFilterPolicy.AutoSize = $true;
         $chckEXOHostedContentFilterPolicy.Name = "chckEXOHostedContentFilterPolicy"
         $chckEXOHostedContentFilterPolicy.Checked = $true
@@ -191,7 +207,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOHostedContentFilterPolicy)
 
         $chckEXOHostedContentFilterRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOHostedContentFilterRule.Top = 300
+        $chckEXOHostedContentFilterRule.Top = 340
         $chckEXOHostedContentFilterRule.AutoSize = $true;
         $chckEXOHostedContentFilterRule.Name = "chckEXOHostedContentFilterRule"
         $chckEXOHostedContentFilterRule.Checked = $true
@@ -199,7 +215,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOHostedContentFilterRule)
 
         $chckEXOHostedOutboundSpamFilterPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOHostedOutboundSpamFilterPolicy.Top = 320
+        $chckEXOHostedOutboundSpamFilterPolicy.Top = 360
         $chckEXOHostedOutboundSpamFilterPolicy.AutoSize = $true;
         $chckEXOHostedOutboundSpamFilterPolicy.Name = "chckEXOHostedOutboundSpamFilterPolicy"
         $chckEXOHostedOutboundSpamFilterPolicy.Checked = $true
@@ -207,7 +223,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOHostedOutboundSpamFilterPolicy)
 
         $chckEXOInboundConnector = New-Object System.Windows.Forms.CheckBox
-        $chckEXOInboundConnector.Top = 340
+        $chckEXOInboundConnector.Top = 380
         $chckEXOInboundConnector.AutoSize = $true;
         $chckEXOInboundConnector.Name = "chckEXOInboundConnector"
         $chckEXOInboundConnector.Checked = $true
@@ -215,7 +231,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOInboundConnector)
 
         $chckEXOIntraOrganizationConnector = New-Object System.Windows.Forms.CheckBox
-        $chckEXOIntraOrganizationConnector.Top = 360
+        $chckEXOIntraOrganizationConnector.Top = 400
         $chckEXOIntraOrganizationConnector.AutoSize = $true;
         $chckEXOIntraOrganizationConnector.Name = "chckEXOIntraOrganizationConnector"
         $chckEXOIntraOrganizationConnector.Checked = $true
@@ -223,7 +239,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOIntraOrganizationConnector)
 
         $chckEXOMailboxSettings = New-Object System.Windows.Forms.CheckBox
-        $chckEXOMailboxSettings.Top = 380
+        $chckEXOMailboxSettings.Top = 420
         $chckEXOMailboxSettings.AutoSize = $true;
         $chckEXOMailboxSettings.Name = "chckEXOMailboxSettings"
         $chckEXOMailboxSettings.Checked = $true
@@ -231,7 +247,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOMailboxSettings)
 
         $chckEXOMailTips = New-Object System.Windows.Forms.CheckBox
-        $chckEXOMailTips.Top = 400
+        $chckEXOMailTips.Top = 440
         $chckEXOMailTips.AutoSize = $true;
         $chckEXOMailTips.Name = "chckEXOMailTips"
         $chckEXOMailTips.Checked = $true
@@ -239,7 +255,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOMailTips);
 
         $chckEXOMalwareFilterPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOMalwareFilterPolicy.Top = 420
+        $chckEXOMalwareFilterPolicy.Top = 460
         $chckEXOMalwareFilterPolicy.AutoSize = $true;
         $chckEXOMalwareFilterPolicy.Name = "chckEXOMalwareFilterPolicy"
         $chckEXOMalwareFilterPolicy.Checked = $true
@@ -247,15 +263,23 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOMalwareFilterPolicy);
 
         $chckEXOMalwareFilterRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOMalwareFilterRule.Top = 440
+        $chckEXOMalwareFilterRule.Top = 480
         $chckEXOMalwareFilterRule.AutoSize = $true;
         $chckEXOMalwareFilterRule.Name = "chckEXOMalwareFilterRule"
         $chckEXOMalwareFilterRule.Checked = $true
         $chckEXOMalwareFilterRule.Text = "Malware Filter Rule"
         $pnlExo.Controls.Add($chckEXOMalwareFilterRule);
 
+        $chckEXOManagementRole = New-Object System.Windows.Forms.CheckBox
+        $chckEXOManagementRole.Top = 500
+        $chckEXOManagementRole.AutoSize = $true;
+        $chckEXOManagementRole.Name = "chckEXOManagementRole"
+        $chckEXOManagementRole.Checked = $true
+        $chckEXOManagementRole.Text = "Management Roles"
+        $pnlExo.Controls.Add($chckEXOManagementRole);
+
         $chckEXOMobileDeviceMailboxPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOMobileDeviceMailboxPolicy.Top = 460
+        $chckEXOMobileDeviceMailboxPolicy.Top = 520
         $chckEXOMobileDeviceMailboxPolicy.AutoSize = $true;
         $chckEXOMobileDeviceMailboxPolicy.Name = "chckEXOMobileDeviceMailboxPolicy"
         $chckEXOMobileDeviceMailboxPolicy.Checked = $true
@@ -263,7 +287,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOMobileDeviceMailboxPolicy);
 
         $chckEXOOfflineAddressBook = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOfflineAddressBook.Top = 480
+        $chckEXOOfflineAddressBook.Top = 540
         $chckEXOOfflineAddressBook.AutoSize = $true;
         $chckEXOOfflineAddressBook.Name = "chckEXOOfflineAddressBook"
         $chckEXOOfflineAddressBook.Checked = $true
@@ -271,7 +295,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOfflineAddressBook);
 
         $chckEXOOnPremisesOrganization = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOnPremisesOrganization.Top = 500
+        $chckEXOOnPremisesOrganization.Top = 560
         $chckEXOOnPremisesOrganization.AutoSize = $true;
         $chckEXOOnPremisesOrganization.Name = "chckEXOOnPremisesOrganization"
         $chckEXOOnPremisesOrganization.Checked = $true
@@ -279,7 +303,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOnPremisesOrganization)
 
         $chckEXOOrganizationConfig = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOrganizationConfig.Top = 520
+        $chckEXOOrganizationConfig.Top = 580
         $chckEXOOrganizationConfig.AutoSize = $true;
         $chckEXOOrganizationConfig.Name = "chckEXOOrganizationConfig"
         $chckEXOOrganizationConfig.Checked = $true
@@ -287,7 +311,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOrganizationConfig);
 
         $chckEXOOrganizationRelationship = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOrganizationRelationship.Top = 540
+        $chckEXOOrganizationRelationship.Top = 600
         $chckEXOOrganizationRelationship.AutoSize = $true;
         $chckEXOOrganizationRelationship.Name = "chckEXOOrganizationRelationship"
         $chckEXOOrganizationRelationship.Checked = $true
@@ -295,7 +319,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOrganizationRelationship)
 
         $chckEXOOutboundConnector = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOutboundConnector.Top = 560
+        $chckEXOOutboundConnector.Top = 620
         $chckEXOOutboundConnector.AutoSize = $true;
         $chckEXOOutboundConnector.Name = "chckEXOOutboundConnector"
         $chckEXOOutboundConnector.Checked = $true
@@ -303,7 +327,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOutboundConnector)
 
         $chckEXOOwaMailboxPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOOwaMailboxPolicy.Top = 580
+        $chckEXOOwaMailboxPolicy.Top = 640
         $chckEXOOwaMailboxPolicy.AutoSize = $true;
         $chckEXOOwaMailboxPolicy.Name = "chckEXOOwaMailboxPolicy"
         $chckEXOOwaMailboxPolicy.Checked = $true
@@ -311,7 +335,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOOwaMailboxPolicy)
 
         $chckEXOPartnerApplication = New-Object System.Windows.Forms.CheckBox
-        $chckEXOPartnerApplication.Top = 600
+        $chckEXOPartnerApplication.Top = 660
         $chckEXOPartnerApplication.AutoSize = $true;
         $chckEXOPartnerApplication.Name = "chckEXOPartnerApplication"
         $chckEXOPartnerApplication.Checked = $true
@@ -319,7 +343,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOPartnerApplication)
 
         $chckEXOPolicyTipConfig = New-Object System.Windows.Forms.CheckBox
-        $chckEXOPolicyTipConfig.Top = 620
+        $chckEXOPolicyTipConfig.Top = 680
         $chckEXOPolicyTipConfig.AutoSize = $true;
         $chckEXOPolicyTipConfig.Name = "chckEXOPolicyTipConfig"
         $chckEXOPolicyTipConfig.Checked = $true
@@ -327,15 +351,23 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOPolicyTipConfig)
 
         $chckEXORemoteDomain = New-Object System.Windows.Forms.CheckBox
-        $chckEXORemoteDomain.Top = 640
+        $chckEXORemoteDomain.Top = 700
         $chckEXORemoteDomain.AutoSize = $true;
         $chckEXORemoteDomain.Name = "chckEXORemoteDomain"
         $chckEXORemoteDomain.Checked = $true
         $chckEXORemoteDomain.Text = "Remote Domains"
         $pnlExo.Controls.Add($chckEXORemoteDomain)
 
+        $chckEXORoleAssignmentPolicy = New-Object System.Windows.Forms.CheckBox
+        $chckEXORoleAssignmentPolicy.Top = 720
+        $chckEXORoleAssignmentPolicy.AutoSize = $true;
+        $chckEXORoleAssignmentPolicy.Name = "chckEXORoleAssignmentPolicy"
+        $chckEXORoleAssignmentPolicy.Checked = $true
+        $chckEXORoleAssignmentPolicy.Text = "Role Assignment Policies"
+        $pnlExo.Controls.Add($chckEXORoleAssignmentPolicy)
+
         $chckEXOSafeAttachmentPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSafeAttachmentPolicy.Top = 660
+        $chckEXOSafeAttachmentPolicy.Top = 740
         $chckEXOSafeAttachmentPolicy.AutoSize = $true;
         $chckEXOSafeAttachmentPolicy.Name = "chckEXOSafeAttachmentPolicy"
         $chckEXOSafeAttachmentPolicy.Checked = $true
@@ -343,7 +375,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOSafeAttachmentPolicy)
 
         $chckEXOSafeAttachmentRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSafeAttachmentRule.Top = 680
+        $chckEXOSafeAttachmentRule.Top = 760
         $chckEXOSafeAttachmentRule.AutoSize = $true;
         $chckEXOSafeAttachmentRule.Name = "chckEXOSafeAttachmentRule"
         $chckEXOSafeAttachmentRule.Checked = $true
@@ -351,7 +383,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOSafeAttachmentRule)
 
         $chckEXOSafeLinksPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSafeLinksPolicy.Top = 700
+        $chckEXOSafeLinksPolicy.Top = 780
         $chckEXOSafeLinksPolicy.AutoSize = $true;
         $chckEXOSafeLinksPolicy.Name = "chckEXOSafeLinksPolicy"
         $chckEXOSafeLinksPolicy.Checked = $true
@@ -359,7 +391,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOSafeLinksPolicy)
 
         $chckEXOSafeLinksRule = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSafeLinksRule.Top = 720
+        $chckEXOSafeLinksRule.Top = 800
         $chckEXOSafeLinksRule.AutoSize = $true;
         $chckEXOSafeLinksRule.Name = "chckEXOSafeLinksRule"
         $chckEXOSafeLinksRule.Checked = $true
@@ -367,7 +399,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOSafeLinksRule)
 
         $chckEXOSharedMailbox = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSharedMailbox.Top = 740
+        $chckEXOSharedMailbox.Top = 820
         $chckEXOSharedMailbox.AutoSize = $true;
         $chckEXOSharedMailbox.Name = "chckEXOSharedMailbox"
         $chckEXOSharedMailbox.Checked = $true
@@ -375,7 +407,7 @@ function Show-O365GUI
         $pnlExo.Controls.Add($chckEXOSharedMailbox)
 
         $chckEXOSharingPolicy = New-Object System.Windows.Forms.CheckBox
-        $chckEXOSharingPolicy.Top = 760
+        $chckEXOSharingPolicy.Top = 840
         $chckEXOSharingPolicy.AutoSize = $true;
         $chckEXOSharingPolicy.Name = "chckEXOSharingPolicy"
         $chckEXOSharingPolicy.Checked = $true

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -1021,12 +1021,11 @@ function Get-AllTeamsCached
             $accessToken = Get-AppIdentityAccessToken $endpoint
             $httpClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken");
             $allTeams.AddRange([Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($httpClient, $requestUri)))
-            Write-Information "Retrieved all teams"
+            Write-Verbose "Retrieved all teams"
         }
 
 
         $allTeams = $allTeams | Where-Object {
-
             $_.ResourceProvisioningOptions.Contains("Team")
         }
 
@@ -1037,22 +1036,12 @@ function Get-AllTeamsCached
                 $teamToRetrieve = $_
                 Invoke-With429Retry -ScriptBlock {
                     $accessToken = Get-AppIdentityAccessToken $endpoint
-                    Write-Information "got single item access token"
                     $singleTeamClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken")
                     $groupId= $teamToRetrieve.GroupId
                     $singleTeamRequestUri = [Uri]::new("$endpoint/v1.0/teams/$groupId")
-                    Write-Information "retrieving $groupId"
                     Write-Verbose "retrieving from $singleTeamRequestUri"
                     [Type[]]$types = @([System.Net.Http.HttpClient], [Uri])
-                    # try
-                    # {
-                        $team = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("Get", $types).MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($singleTeamClient, $singleTeamRequestUri))
-                    # }
-                    # catch
-                    # {
-                    #     Write-Host "WTF"
-                    # }
-                    Write-Information "Retrieved single item team"
+                    $team = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("Get", $types).MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($singleTeamClient, $singleTeamRequestUri))
                     $team.DisplayName = $_.DisplayName
                     $team.Description = $_.Description
                     $team.Visibility = $_.Visibility
@@ -1064,7 +1053,6 @@ function Get-AllTeamsCached
             }
             finally
             {
-                Write-Information "Disposed context"
                 $singleTeamClient.Dispose()
             }
         }

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -992,9 +992,12 @@ function Get-AllTeamsCached
     [CmdletBinding()]
     param
     (
+        [Parameter()]
+        [Switch]
+        $ForceRefresh
     )
 
-    if($Global:O365TeamsCached)
+    if($Global:O365TeamsCached -and !$ForceRefresh)
     {
         return $Global:O365TeamsCached
     }
@@ -1071,7 +1074,8 @@ function Get-AllTeamsCached
         $httpClient.Dispose()
     }
 
-    return $allTeamSettings
+    $Global:O365TeamsCached = $allTeamSettings
+    return $Global:O365TeamsCached
 }
 
 

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -999,6 +999,7 @@ function Get-AllTeamsCached
         return $Global:O365TeamsCached
     }
 
+    $allTeams = New-Object Collections.Generic.List[Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]
     $allTeamSettings = New-Object Collections.Generic.List[Microsoft.TeamsCmdlets.PowerShell.Custom.Model.TeamSettings]
 
     $endpoint = "https://graph.microsoft.com"
@@ -1008,30 +1009,47 @@ function Get-AllTeamsCached
     # this is actually the only way to get the team details, but when running in parallel without any limits
     # throttling is bound to come up and it is NOT handled at all
     # Get-Team
+    $accessToken = Get-AppIdentityAccessToken $endpoint
     $httpClient = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities]::GetClient("Bearer $accessToken", "Get-TeamTraceCustom")
     try
     {
         $requestUri = [Uri]::new("$endpoint/v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')&`$select=id,resourceProvisioningOptions,displayName,description,visibility,mailnickname,classification")
         Invoke-WithRetry -ScriptBlock {
-            $accessToken = Get-AppIdentityAccessToken $endpoint
+
             $httpClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken");
-            $allTeams = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, $httpClient, $requestUri)
+            $allTeams.AddRange([Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($httpClient, $requestUri)))
+            Write-Information "Retrieved all teams"
         }
 
 
-        $allTeams = $allTeams | Where-Object {$_.ResourceProvisioningOptions.Contains("Team")}
+        $allTeams = $allTeams | Where-Object {
 
-        $allTeams | ForEach-Object
-        {
+            $_.ResourceProvisioningOptions.Contains("Team")
+        }
+
+        $allTeams | ForEach-Object {
             try
             {
                 $singleTeamClient = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities]::GetClient("Bearer $accessToken", "Get-TeamTraceCustom")
+                $teamToRetrieve = $_
                 Invoke-WithRetry -ScriptBlock {
-                    $accessToken = Get-AppIdentityAccessToken $endpoint
+                    # $accessToken = Get-AppIdentityAccessToken $endpoint
+                    Write-Information "got single item access token"
                     $singleTeamClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken")
-                    $groupId= $_.GroupId
+                    $groupId= $teamToRetrieve.GroupId
                     $singleTeamRequestUri = [Uri]::new("$endpoint/v1.0/teams/$groupId")
-                    $team = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("Get").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, $httpClient, $requestUri)
+                    Write-Information "retrieving $groupId"
+                    Write-Verbose "retrieving from $singleTeamRequestUri"
+                    [Type[]]$types = @([System.Net.Http.HttpClient], [Uri])
+                    # try
+                    # {
+                        $team = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("Get", $types).MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($singleTeamClient, $singleTeamRequestUri))
+                    # }
+                    # catch
+                    # {
+                    #     Write-Host "WTF"
+                    # }
+                    Write-Information "Retrieved single item team"
                     $team.DisplayName = $_.DisplayName
                     $team.Description = $_.Description
                     $team.Visibility = $_.Visibility
@@ -1043,6 +1061,7 @@ function Get-AllTeamsCached
             }
             finally
             {
+                Write-Information "Disposed context"
                 $singleTeamClient.Dispose()
             }
         }
@@ -1073,19 +1092,23 @@ function Invoke-WithRetry
 
     $retryCount = 10
     $backoffPeriodMiliseconds = 500
-
     do
     {
+
+        # Write-Information "Trying to execute ScriptBlock, retry count: $retryCount"
         try
         {
-            $ScriptBlock.Invoke()
+            Invoke-Command $ScriptBlock
+            break
         }
         catch
         {
-            if($_.HttpStatusCode -ne "TooManyRequests" -or $retryCount -eq 0)
+            if($null -eq $_.Exception -or $null -eq $_.Exception.InnerException -or $_.Exception.InnerException.ErrorCode -ne 429 -or $retryCount -eq 0)
             {
                 throw
             }
+
+            Write-Information "The request has been throttled, will retry, retryCount: $retryCount"
         }
         Start-Sleep -Milliseconds $backoffPeriodMiliseconds
         $retryCount = $retryCount - 1

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -978,6 +978,122 @@ function Get-TeamByName
     return $team
 }
 
+function Reset-AllTeamsCached
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    $Global:O365TeamsCached = $null
+}
+function Get-AllTeamsCached
+{
+    [CmdletBinding()]
+    param
+    (
+    )
+
+    if($Global:O365TeamsCached)
+    {
+        return $Global:O365TeamsCached
+    }
+
+    $allTeamSettings = New-Object Collections.Generic.List[Microsoft.TeamsCmdlets.PowerShell.Custom.Model.TeamSettings]
+
+    $endpoint = "https://graph.microsoft.com"
+
+    # The Get-Team cmdlet was not really written with throttling in mind
+    # internally, they get the list of teams and then in parallel go to the /teams/{id} endpoint
+    # this is actually the only way to get the team details, but when running in parallel without any limits
+    # throttling is bound to come up and it is NOT handled at all
+    # Get-Team
+    $httpClient = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities]::GetClient("Bearer $accessToken", "Get-TeamTraceCustom")
+    try
+    {
+        $requestUri = [Uri]::new("$endpoint/v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')&`$select=id,resourceProvisioningOptions,displayName,description,visibility,mailnickname,classification")
+        Invoke-WithRetry -ScriptBlock {
+            $accessToken = Get-AppIdentityAccessToken $endpoint
+            $httpClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken");
+            $allTeams = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, $httpClient, $requestUri)
+        }
+
+
+        $allTeams = $allTeams | Where-Object {$_.ResourceProvisioningOptions.Contains("Team")}
+
+        $allTeams | ForEach-Object
+        {
+            try
+            {
+                $singleTeamClient = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities]::GetClient("Bearer $accessToken", "Get-TeamTraceCustom")
+                Invoke-WithRetry -ScriptBlock {
+                    $accessToken = Get-AppIdentityAccessToken $endpoint
+                    $singleTeamClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken")
+                    $groupId= $_.GroupId
+                    $singleTeamRequestUri = [Uri]::new("$endpoint/v1.0/teams/$groupId")
+                    $team = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("Get").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, $httpClient, $requestUri)
+                    $team.DisplayName = $_.DisplayName
+                    $team.Description = $_.Description
+                    $team.Visibility = $_.Visibility
+                    $team.MailNickName = $_.MailNickName
+                    $team.Classification = $_.Classification
+
+                    $allTeamSettings.Add([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.TeamSettings]::new($team))
+                }
+            }
+            finally
+            {
+                $singleTeamClient.Dispose()
+            }
+        }
+    }
+    finally
+    {
+        $httpClient.Dispose()
+    }
+
+    return $allTeamSettings
+}
+
+
+function Invoke-WithRetry
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ScriptBlock]
+        $ScriptBlock
+    )
+
+    if($null -eq $Global:O365DSCBackoffRandomizer)
+    {
+        $Global:O365DSCBackoffRandomizer = [System.Random]::new()
+    }
+
+    $retryCount = 10
+    $backoffPeriodMiliseconds = 500
+
+    do
+    {
+        try
+        {
+            $ScriptBlock.Invoke()
+        }
+        catch
+        {
+            if($_.HttpStatusCode -ne "TooManyRequests" -or $retryCount -eq 0)
+            {
+                throw
+            }
+        }
+        Start-Sleep -Milliseconds $backoffPeriodMiliseconds
+        $retryCount = $retryCount - 1
+        $backoffPeriodMiliseconds = $backoffPeriodMiliseconds * 2 + $Global:O365DSCBackoffRandomizer.Next($backoffPeriodMiliseconds / 10)
+    }
+    while ($retryCount -gt 0)
+}
+
 function Convert-O365DscHashtableToString
 {
     param


### PR DESCRIPTION
Added Get-AllTeamsCached which reimplements the Get-Team logic
Added Invoke-With429Retry

It's interesting that you cannot just reassign a variable inside a scriptblock, it has no effect. This is why the collections are initialized beforehand and then we add to them from within the ScriptBlock