### PR TITLE
Character escaping logic

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
@@ -259,7 +259,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOAcceptedDomain " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
@@ -253,7 +253,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOActiveSyncDeviceAccessRule " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
@@ -264,7 +264,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOAddressBookPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -562,7 +562,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "      EXOAddressList " + (New-Guid).ToString() + "`r`n"
         $content += "      {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "      }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
@@ -526,7 +526,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOAntiPhishPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
@@ -353,7 +353,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOAntiPhishRule " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
@@ -294,7 +294,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOApplicationAccessPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -274,7 +274,7 @@ function Export-TargetResource
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        EXOAtpPolicyForO365 " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
                 $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
                 if ($currentDSCBlock.ToLower().IndexOf($organization.ToLower()) -gt 0)
                 {

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
@@ -290,7 +290,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOAvailabilityAddressSpace " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
@@ -175,7 +175,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        EXOAvailabilityConfig " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
@@ -225,7 +225,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOCASMailboxPlan " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
@@ -385,7 +385,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXOClientAccessRule " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
         }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
@@ -289,7 +289,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXODkimSigningConfig " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)
             {
                 $partialContent = $partialContent -ireplace [regex]::Escape($organization), "`$OrganizationName"

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
@@ -277,7 +277,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOEmailAddressPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
@@ -553,7 +553,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOGlobalAddressList " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
@@ -291,7 +291,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOHostedConnectionFilterPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -880,7 +880,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOHostedContentFilterPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -343,7 +343,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOHostedContentFilterRule " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
@@ -230,7 +230,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOHostedOutboundSpamFilterPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
@@ -342,7 +342,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOInboundConnector " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
@@ -207,7 +207,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOIntraOrganizationConnector " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOMailTips/MSFT_EXOMailTips.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOMailTips/MSFT_EXOMailTips.psm1
@@ -273,7 +273,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        EXOMailTips " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
     if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)
     {

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
@@ -220,7 +220,7 @@ function Export-TargetResource
                 $modulePath = $PSScriptRoot + "\MSFT_EXOMailboxSettings.psm1"
                 $content += "        EXOMailboxSettings " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $modulePath
+                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $modulePath
                 $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                 $content += "        }`r`n"
             }

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
@@ -438,7 +438,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOMalwareFilterPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
@@ -308,7 +308,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOMalwareFilterRule " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
@@ -240,7 +240,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOManagementRole " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
@@ -1029,7 +1029,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOMobileDeviceMailboxPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
@@ -276,7 +276,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOOfflineAddressBook " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
@@ -311,7 +311,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOOnPremisesOrganization " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
@@ -1001,7 +1001,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        EXOOrganizationConfig " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -512,7 +512,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOOrganizationRelationship " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
@@ -374,7 +374,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        EXOOutboundConnector " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -1347,7 +1347,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOOwaMailboxPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
@@ -284,7 +284,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOPartnerApplication " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
@@ -216,7 +216,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOPolicyTipConfig " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
@@ -514,7 +514,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXORemoteDomain " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
@@ -260,7 +260,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXORoleAssignmentPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
@@ -273,7 +273,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXOSafeAttachmentPolicy " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
@@ -343,7 +343,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXOSafeAttachmentRule " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -293,7 +293,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXOSafeLinksPolicy " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
@@ -335,7 +335,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        EXOSafeLinksRule " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
@@ -285,7 +285,7 @@ function Export-TargetResource
             $modulePath = $PSScriptRoot + "\MSFT_EXOSharedMailbox.psm1"
             $content += "        EXOSharedMailbox " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $partialContent = Get-DSCBlock -Params $result -ModulePath $modulePath
+            $partialContent = Get-DSCBlockEx -Params $result -ModulePath $modulePath
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
             if ($partialContent.ToLower().IndexOf("@" + $organization.ToLower()) -gt 0)
             {

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
@@ -252,7 +252,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content = "        EXOSharingPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content

--- a/Modules/Office365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
@@ -213,7 +213,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        O365AdminAuditLogConfig " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -397,7 +397,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = "`$Credsglobaladmin"
         $content += "        O365Group " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)
         {

--- a/Modules/Office365DSC/DSCResources/MSFT_O365OrgCustomizationSetting/MSFT_O365OrgCustomizationSetting.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365OrgCustomizationSetting/MSFT_O365OrgCustomizationSetting.psm1
@@ -151,7 +151,7 @@ function Export-TargetResource
     {
         $content = "        O365OrgCustomizationSetting " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -622,7 +622,7 @@ function Export-TargetResource
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        O365User " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $partialContent = Get-DSCBlock -Params $result -ModulePath  $PSScriptRoot
+                $partialContent = Get-DSCBlockEx -Params $result -ModulePath  $PSScriptRoot
                 $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "Password"
                 $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
                 if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)

--- a/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -622,7 +622,7 @@ function Export-TargetResource
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        O365User " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $partialContent = Get-DSCBlockEx -Params $result -ModulePath  $PSScriptRoot
+                $partialContent = Get-DSCBlockEx -Params $result -ModulePath  $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("Password")
                 $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "Password"
                 $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
                 if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)

--- a/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -350,7 +350,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        ODSettings " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -228,7 +228,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        PPPowerAppsEnvironment " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
         }

--- a/Modules/Office365DSC/DSCResources/MSFT_SCAuditConfigurationPolicy/MSFT_SCAuditConfigurationPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCAuditConfigurationPolicy/MSFT_SCAuditConfigurationPolicy.psm1
@@ -197,7 +197,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCAuditConfigurationPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
 

--- a/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
@@ -336,7 +336,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $dscContent += "        SCCaseHoldPolicy " + (New-GUID).ToString() + "`r`n"
             $dscContent += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $partialContent += "        }`r`n"
             $dscContent += $partialContent

--- a/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldRule/MSFT_SCCaseHoldRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldRule/MSFT_SCCaseHoldRule.psm1
@@ -244,7 +244,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $dscContent += "        SCCaseHoldRule " + (New-GUID).ToString() + "`r`n"
             $dscContent += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $partialContent += "        }`r`n"
             $dscContent += $partialContent

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
@@ -235,7 +235,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $dscContent += "        SCComplianceCase " + (New-GUID).ToString() + "`r`n"
         $dscContent += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $partialContent += "        }`r`n"
         $dscContent += $partialContent
@@ -256,7 +256,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $dscContent += "        SCComplianceCase " + (New-GUID).ToString() + "`r`n"
         $dscContent += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $partialContent += "        }`r`n"
         $dscContent += $partialContent

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
@@ -364,7 +364,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $DSCContent = "        SCComplianceSearch " + (New-GUID).ToString() + "`r`n"
         $DSCContent += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $partialContent += "        }`r`n"
         $DSCContent += $partialContent
@@ -393,7 +393,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $DSCContent += "        SCComplianceSearch " + (New-GUID).ToString() + "`r`n"
             $DSCContent += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $partialContent += "        }`r`n"
             $DSCContent += $partialContent

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
@@ -402,7 +402,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCComplianceSearchAction " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++
@@ -438,7 +438,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        SCComplianceSearchAction " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
@@ -388,7 +388,7 @@ function Export-TargetResource
         $result.FilePlanProperty = Get-SCFilePlanPropertyAsString $result.FilePlanProperty
         $content += "        SCComplianceTag " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("FilePlanProperty")
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "FilePlanProperty"
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
@@ -388,7 +388,7 @@ function Export-TargetResource
         $result.FilePlanProperty = Get-SCFilePlanPropertyAsString $result.FilePlanProperty
         $content += "        SCComplianceTag " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "FilePlanProperty"
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCDLPCompliancePolicy/MSFT_SCDLPCompliancePolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCDLPCompliancePolicy/MSFT_SCDLPCompliancePolicy.psm1
@@ -497,7 +497,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCDLPCompliancePolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -508,7 +508,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $DSCContent += "        SCDLPComplianceRule " + (New-GUID).ToString() + "`r`n"
         $DSCContent += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "ContentContainsSensitiveInformation" -IsCIMArray $IsCIMArray
 
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -508,7 +508,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $DSCContent += "        SCDLPComplianceRule " + (New-GUID).ToString() + "`r`n"
         $DSCContent += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("ContentContainsSensitiveInformation")
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "ContentContainsSensitiveInformation" -IsCIMArray $IsCIMArray
 
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyAuthority/MSFT_SCFilePlanPropertyAuthority.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyAuthority/MSFT_SCFilePlanPropertyAuthority.psm1
@@ -176,7 +176,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertyAuthority " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyCategory/MSFT_SCFilePlanPropertyCategory.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyCategory/MSFT_SCFilePlanPropertyCategory.psm1
@@ -176,7 +176,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertyCategory " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyCitation/MSFT_SCFilePlanPropertyCitation.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyCitation/MSFT_SCFilePlanPropertyCitation.psm1
@@ -202,7 +202,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertyCitation " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyDepartment/MSFT_SCFilePlanPropertyDepartment.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyDepartment/MSFT_SCFilePlanPropertyDepartment.psm1
@@ -176,7 +176,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertyDepartment " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyReferenceId/MSFT_SCFilePlanPropertyReferenceId.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertyReferenceId/MSFT_SCFilePlanPropertyReferenceId.psm1
@@ -176,7 +176,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertyReferenceId " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertySubCategory/MSFT_SCFilePlanPropertySubCategory.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCFilePlanPropertySubCategory/MSFT_SCFilePlanPropertySubCategory.psm1
@@ -202,7 +202,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCFilePlanPropertySubCategory " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
@@ -681,7 +681,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCRetentionCompliancePolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().Contains($organization.ToLower()) -or `
                         $partialContent.ToLower().Contains($principal.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
@@ -333,7 +333,7 @@ function Export-TargetResource
 
             $content += "        SCRetentionComplianceRule " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
             if ($partialContent.ToLower().Contains($organization.ToLower()) -or `
                     $partialContent.ToLower().Contains($principal.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -408,7 +408,7 @@ function Export-TargetResource
             }
             $content += "        SCSensitivityLabel " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "AdvancedSettings"
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "LocaleSettings"
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -408,7 +408,7 @@ function Export-TargetResource
             }
             $content += "        SCSensitivityLabel " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("AdvancedSettings","LocaleSettings")
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "AdvancedSettings"
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "LocaleSettings"
             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"

--- a/Modules/Office365DSC/DSCResources/MSFT_SCSupervisoryReviewPolicy/MSFT_SCSupervisoryReviewPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCSupervisoryReviewPolicy/MSFT_SCSupervisoryReviewPolicy.psm1
@@ -229,7 +229,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCSupervisoryReviewPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().Contains($organization.ToLower()) -or `
             $partialContent.ToLower().Contains($principal.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_SCSupervisoryReviewRule/MSFT_SCSupervisoryReviewRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCSupervisoryReviewRule/MSFT_SCSupervisoryReviewRule.psm1
@@ -244,7 +244,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SCSupervisoryReviewRule " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().Contains($organization.ToLower()) -or `
                 $partialContent.ToLower().Contains($principal.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOAccessControlSettings/MSFT_SPOAccessControlSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOAccessControlSettings/MSFT_SPOAccessControlSettings.psm1
@@ -326,7 +326,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        SPOAccessControlSettings " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
@@ -240,7 +240,7 @@ function Export-TargetResource
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        SPOApp " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
                 $convertedContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                 $content += $convertedContent
                 $content += "        }`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
@@ -186,7 +186,7 @@ function Export-TargetResource
 
     $content = "        SPOHomeSite " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
@@ -182,6 +182,10 @@ function Export-TargetResource
     }
 
     $result = Get-TargetResource @params
+    if($result.Ensure -eq "Absent")
+    {
+        return ""
+    }
     $result.GlobalAdminAccount = "`$Credsglobaladmin"
 
     $content = "        SPOHomeSite " + (New-GUID).ToString() + "`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOHubSite/MSFT_SPOHubSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOHubSite/MSFT_SPOHubSite.psm1
@@ -493,7 +493,7 @@ function Export-TargetResource
 
         $content += "        SPOHubSite " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().Contains($organization.ToLower()) -or `
             $partialContent.ToLower().Contains($principal.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
@@ -293,7 +293,7 @@ function Export-TargetResource
                                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                                 $content += "        SPOPropertyBag " + (New-GUID).ToString() + "`r`n"
                                 $content += "        {`r`n"
-                                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $params.ScriptRoot
+                                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $params.ScriptRoot
                                 $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                                 $content += "        }`r`n"
                             }

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSearchManagedProperty/MSFT_SPOSearchManagedProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSearchManagedProperty/MSFT_SPOSearchManagedProperty.psm1
@@ -775,7 +775,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SPOSearchManagedProperty " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSearchResultSource/MSFT_SPOSearchResultSource.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSearchResultSource/MSFT_SPOSearchResultSource.psm1
@@ -466,7 +466,7 @@ function Export-TargetResource
         }
         $content += "        SPOSearchResultSource " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
@@ -509,7 +509,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        SPOSharingSettings " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -755,7 +755,7 @@ function Export-TargetResource
 
             $content += "        SPOSite " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
             if ($partialContent.ToLower().Contains($principal.ToLower() + ".sharepoint.com"))
             {

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSiteDesign/MSFT_SPOSiteDesign.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSiteDesign/MSFT_SPOSiteDesign.psm1
@@ -322,7 +322,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SPOSiteDesign " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSiteDesignRights/MSFT_SPOSiteDesignRights.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSiteDesignRights/MSFT_SPOSiteDesignRights.psm1
@@ -266,7 +266,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        SPOSiteDesignRights " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
         }
@@ -282,7 +282,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        SPOSiteDesignRights " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
         }

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -375,7 +375,7 @@ function Export-TargetResource
                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                 $content += "        SPOSiteGroup " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
-                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
                 $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                 $content += "        }`r`n"
             }

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
@@ -295,7 +295,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SPOStorageEntity " + (New-Guid).ToString() + "`r`n"
         $content += "        {`r`n"
-        $partialContent = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $partialContent = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent -ParameterName "GlobalAdminAccount"
         if ($partialContent.ToLower().Contains("https://" + $principal.ToLower()))
         {

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
@@ -188,7 +188,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SPOTenantCDNPolicy " + (New-Guid).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }
@@ -204,7 +204,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        SPOTenantCDNPolicy " + (New-Guid).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
     }

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -432,7 +432,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        SPOTenantSettings " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
@@ -237,7 +237,7 @@ function Export-TargetResource
         $result.Palette = ConvertTo-SPOThemePalettePropertyString -Palette $result.Palette
         $content += "        SPOTheme " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Palette"
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += $currentDSCBlock

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
@@ -237,7 +237,7 @@ function Export-TargetResource
         $result.Palette = ConvertTo-SPOThemePalettePropertyString -Palette $result.Palette
         $content += "        SPOTheme " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("Palette")
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Palette"
         $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += $currentDSCBlock

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -260,7 +260,7 @@ function Export-TargetResource
                             $content += "        SPOUserProfileProperty " + (New-GUID).ToString() + "`r`n"
                             $content += "        {`r`n"
 
-                            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $params.ScriptRoot
+                            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $params.ScriptRoot -PropertiesWithAllowedSpecialCharacters @("Properties")
                             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Properties" -IsCIMArray $true
                             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                             $content += $currentDSCBlock

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -260,7 +260,7 @@ function Export-TargetResource
                             $content += "        SPOUserProfileProperty " + (New-GUID).ToString() + "`r`n"
                             $content += "        {`r`n"
 
-                            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $params.ScriptRoot
+                            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $params.ScriptRoot
                             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Properties" -IsCIMArray $true
                             $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                             $content += $currentDSCBlock

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsCallingPolicy/MSFT_TeamsCallingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsCallingPolicy/MSFT_TeamsCallingPolicy.psm1
@@ -305,7 +305,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsCallingPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -309,7 +309,7 @@ function Export-TargetResource
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
             $content += "        TeamsChannel " + (New-GUID).ToString() + "`r`n"
             $content += "        {`r`n"
-            $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+            $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
             $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
             $content += "        }`r`n"
             $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
@@ -233,7 +233,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsChannelsPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
@@ -326,7 +326,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsClientConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
@@ -282,7 +282,7 @@ function Export-TargetResource
             $result.EmergencyNumbers = ConvertTo-TeamsEmergencyNumbersString -Numbers $result.EmergencyNumbers
         }
 
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
 
         if ($null -ne $result.EmergencyNumbers)
         {

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
@@ -282,7 +282,7 @@ function Export-TargetResource
             $result.EmergencyNumbers = ConvertTo-TeamsEmergencyNumbersString -Numbers $result.EmergencyNumbers
         }
 
-        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("EmergencyNumbers")
 
         if ($null -ne $result.EmergencyNumbers)
         {

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
@@ -263,7 +263,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsEmergencyCallingPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestCallingConfiguration/MSFT_TeamsGuestCallingConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestCallingConfiguration/MSFT_TeamsGuestCallingConfiguration.psm1
@@ -157,7 +157,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsGuestCallingConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestMeetingConfiguration/MSFT_TeamsGuestMeetingConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestMeetingConfiguration/MSFT_TeamsGuestMeetingConfiguration.psm1
@@ -181,7 +181,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsGuestMeetingConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestMessagingConfiguration/MSFT_TeamsGuestMessagingConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsGuestMessagingConfiguration/MSFT_TeamsGuestMessagingConfiguration.psm1
@@ -262,7 +262,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsGuestMessagingConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
@@ -222,7 +222,7 @@ function Export-TargetResource
     $result.SdnAPIToken = '$ConfigurationData.Settings.SdnApiToken'
     $content = "        TeamsMeetingBroadcastConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $partial = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $partial = Convert-DSCStringParamToVariable -DSCBlock $partial -ParameterName "SdnApiToken"
     $content += $partial

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
@@ -222,7 +222,7 @@ function Export-TargetResource
     $result.SdnAPIToken = '$ConfigurationData.Settings.SdnApiToken'
     $content = "        TeamsMeetingBroadcastConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot -PropertiesWithAllowedSpecialCharacters @("SdnApiToken")
     $partial = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $partial = Convert-DSCStringParamToVariable -DSCBlock $partial -ParameterName "SdnApiToken"
     $content += $partial

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
@@ -253,7 +253,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsMeetingBroadcastPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partial = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += $partial
         $content += "        }`r`n"

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingConfiguration/MSFT_TeamsMeetingConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingConfiguration/MSFT_TeamsMeetingConfiguration.psm1
@@ -315,7 +315,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsMeetingConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
@@ -408,7 +408,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsMeetingPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
@@ -430,7 +430,7 @@ function Export-TargetResource
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
         $content += "        TeamsMessagingPolicy " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $i++

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -574,7 +574,7 @@ function Export-TargetResource
         }
         $content += "        TeamsTeam " + (New-GUID).ToString() + "`r`n"
         $content += "        {`r`n"
-        $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+        $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $partialContent += "        }`r`n"
         if ($partialContent.ToLower().Contains("@" + $organization.ToLower()))

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUpgradeConfiguration/MSFT_TeamsUpgradeConfiguration.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUpgradeConfiguration/MSFT_TeamsUpgradeConfiguration.psm1
@@ -156,7 +156,7 @@ function Export-TargetResource
     $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
     $content = "        TeamsUpgradeConfiguration " + (New-GUID).ToString() + "`r`n"
     $content += "        {`r`n"
-    $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
+    $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $PSScriptRoot
     $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
     $content += "        }`r`n"
     return $content

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -341,7 +341,7 @@ function Export-TargetResource
                                 $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
                                 $content += "        TeamsUser " + (New-GUID).ToString() + "`r`n"
                                 $content += "        {`r`n"
-                                $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $params.ScriptRoot
+                                $currentDSCBlock = Get-DSCBlockEx -Params $result -ModulePath $params.ScriptRoot
                                 $partialContent = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
                                 $partialContent += "        }`r`n"
                                 if ($partialContent.ToLower().Contains($organization.ToLower()))

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -2134,20 +2134,11 @@ function ConvertTo-SPOUserProfilePropertyInstanceString
     $results = @()
     foreach ($property in $Properties)
     {
-        $value = $property.Value
-        if($value -and !($value -is [string]))
-        {
-            $value = $value.ToString()
-        }
-        elseif(!$value)
-        {
-            $value = ""
-        }
-        $value = $value.Replace("`"", "```"")
+        $value = Get-DSCPSTokenValue -Value $property.Value
 
         $content = "             MSFT_SPOUserProfilePropertyInstance`r`n            {`r`n"
         $content += "                Key   = `"$($property.Key)`"`r`n"
-        $content += "                Value = `"$($value)`"`r`n"
+        $content += "                Value = $($value)`r`n"
         $content += "            }`r`n"
         $results += $content
     }


### PR DESCRIPTION
Handling of special characters in the generated .ps1 file.


The original PR description in croatian:
ovaj PR se sastoji od par stvari:
- funkcije za escapeanje znakova Get-DSCPSTokenValue
- Get-DSCBlockEx koji je preuzet iz ReverseDSC. svi pozivi Get-DSCBlock su zamijenjeni s njim jer je zbog start-job i globalno instaliranog ReverseDSC modula to najsigurniji nacin da ce nasu implementaciju zvat
- Neki resursi kod poziva bacaju još koje properties ne treba escapeat
ovo je bitno da se 2x ne escapea nesto jer se podobjekti predaju ko stringovi
- powershell kad se izvrsava uzima defaultni encoding koji moze stvarat probleme ako je fajl spremljen kao utf8 bez BOM
- Po resursu se validira izgenerirani powershell kod jer mi je fakat dosadilo boriti se s ovim exceptionima gdje zbog jednog znaka na krivom mjestu nekog lijevog resursa korisnik ne može vidjeti baš ništa
Ne cini mi se da je na brzinu extractanja utjecalo, kod mene se jos uvijek vrti oko 16 min za full load