### PR TITLE
downgraded the reversedsc version

### DIFF
--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -100,9 +100,11 @@
         #    ModuleName      = "MSCloudLoginAssistant"
         #    RequiredVersion = "1.0.32"
         #},
+        # SysKit Trace currently uses an older version because of some issues
+        # will need to resolve them at some point
         @{
             ModuleName      = "ReverseDSC"
-            RequiredVersion = "2.0.0.6"
+            RequiredVersion = "2.0.0.2"
         },
         # SysKit Trace currently uses an older version because of some issues
         # will need to resolve them at some point


### PR DESCRIPTION
Compared snapshots from both of our tenants with Trace V2 and V3, seems good.

There is actually another part of the fix why this fixes things. At one point I added code in Start-dscInitializedjob that imports the exact version referenced in this file instead of the latest one that would normally be imported when starting a new job. Perhaps at one point a month or two ago  I was already aware of the issue on some level. This is why V2 has problems loading userprofileproperties. This(loading the wrong version) should no longer happer with newer versions.