### PR TITLE
Fixes based on General Atomics issues

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
@@ -10,7 +10,7 @@ function Get-TargetResource
         $Identity,
 
         [Parameter()]
-        [ValidateSet('Authoritative','InternalRelay')]
+        [ValidateSet('Authoritative', 'InternalRelay')]
         [System.String]
         $DomainType = 'Authoritative',
 
@@ -51,8 +51,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $CertificatePassword
+        $CertificatePassword,
 
+        [Parameter()]
+        $RawInputObject
     )
     Write-Verbose -Message "Getting configuration of Accepted Domain for $Identity"
     #region Telemetry
@@ -77,11 +79,19 @@ function Get-TargetResource
             -InboundParameters $PSBoundParameters
     }
 
-    Write-Verbose -Message 'Getting all Accepted Domain'
-    $AllAcceptedDomains = Get-AcceptedDomain
+    $AcceptedDomain = $null
+    if ($RawInputObject)
+    {
+        $AcceptedDomain = $RawInputObject
+    }
+    else
+    {
+        Write-Verbose -Message 'Getting all Accepted Domain'
+        $AllAcceptedDomains = Get-AcceptedDomain
 
-    Write-Verbose -Message 'Filtering Accepted Domain list by Identity'
-    $AcceptedDomain = $AllAcceptedDomains | Where-Object -FilterScript { $_.Identity -eq $Identity }
+        Write-Verbose -Message 'Filtering Accepted Domain list by Identity'
+        $AcceptedDomain = $AllAcceptedDomains | Where-Object -FilterScript { $_.Identity -eq $Identity }
+    }
 
     if ($null -eq $AcceptedDomain)
     {
@@ -89,7 +99,7 @@ function Get-TargetResource
 
         # Check to see if $Identity matches a verified domain in the O365 Tenant
         $ConnectionMode = New-M365DSCConnection -Platform 'AzureAd' `
-           -InboundParameters $PSBoundParameters
+            -InboundParameters $PSBoundParameters
 
         $VerifiedDomains = Get-AzureADDomain | Where-Object -FilterScript { $_.IsVerified }
         $MatchingVerifiedDomain = $VerifiedDomains | Where-Object -FilterScript { $_.Name -eq $Identity }
@@ -162,7 +172,7 @@ function Set-TargetResource
         $Identity,
 
         [Parameter()]
-        [ValidateSet('Authoritative','InternalRelay')]
+        [ValidateSet('Authoritative', 'InternalRelay')]
         [System.String]
         $DomainType = 'Authoritative',
 
@@ -244,7 +254,7 @@ function Test-TargetResource
         $Identity,
 
         [Parameter()]
-        [ValidateSet('Authoritative','InternalRelay')]
+        [ValidateSet('Authoritative', 'InternalRelay')]
         [System.String]
         $DomainType = 'Authoritative',
 
@@ -375,6 +385,7 @@ function Export-TargetResource
             CertificatePassword   = $CertificatePassword
             CertificatePath       = $CertificatePath
             GlobalAdminAccount    = $GlobalAdminAccount
+            RawInputObject        = $domain
         }
         $Results = Get-TargetResource @Params
         $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
@@ -64,6 +64,10 @@ function Get-TargetResource
     return @{
         Identity               = $Identity
         Users                  = $usersList
+        Description            = $policy.Description
+        Mode                   = $policy.Mode
+        NotifySfbUsers         = $policy.NotifySfbUsers
+        Action                 = $policy.Action
         MigrateMeetingsToTeams = $MigrateMeetingsToTeams
         GlobalAdminAccount     = $GlobalAdminAccount
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.schema.mof
@@ -3,6 +3,10 @@ class MSFT_TeamsUpgradePolicy : OMI_BaseResource
 {
     [Key, Description("Identity of the Teams Upgrade Policy.")] String Identity;
     [Write, Description("List of users that will be granted the Upgrade Policy to.")] String Users[];
+    [Write, Description("Description of the policy.")] String Description;
+    [Write, Description("Mode defines in which client incoming chats and calls land as well as in what service (Teams or Skype for Business) new meetings are scheduled in. Mode also governs whether chat, calling, and meeting scheduling functionality are available in the Teams client.")] String Mode;
+    [Write, Description("Determines whether users who are assigned this policy will see a notification in their Skype for Business client about a pending upgrade to Teams. In addition, if NotifySfBUsers=true and TeamsUpgradeConfiguration has DownloadTeams=true, Win32 versions of Skype for Business will silently download the Teams client.")] Boolean NotifySfbUsers;
+    [Write, Description("")] String Action;
     [Write, Description("Specifies whether to move existing Skype for Business meetings organized by the user to Teams. This parameter can only be true if the mode of the specified policy instance is either TeamsOnly or SfBWithTeamsCollabAndMeetings, and if the policy instance is being granted to a specific user. It not possible to trigger meeting migration when granting TeamsUpgradePolicy to the entire tenant.")] Boolean MigrateMeetingsToTeams;
     [Write, Description("Credentials of the SharePoint Global Admin"), EmbeddedInstance("MSFT_Credential")] String GlobalAdminAccount;
 };

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
         [System.String]
         $CertificateThumbprint,
 
-         [Parameter()]
+        [Parameter()]
         $RawInputObject
     )
 
@@ -393,7 +393,7 @@ function Export-TargetResource
                             $users = [System.Collections.ArrayList]:: new()
                             Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
                                 [array]$locUsers = Get-TeamUser -GroupId $team.GroupId
-                                if($locUsers)
+                                if ($locUsers)
                                 {
                                     $users.AddRange($locUsers)
                                 }
@@ -424,7 +424,7 @@ function Export-TargetResource
                                 {
                                     $getParams = @{
                                         TeamName              = $team.DisplayName
-                                        TeamMailNickName   = $team.MailNickName
+                                        TeamMailNickName      = $team.MailNickName
                                         User                  = $user.User
                                         ApplicationId         = $ApplicationId
                                         TenantId              = $TenantId

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -684,7 +684,7 @@ function Remove-RemoteSessions
         # this code is basically copy pasted from Disconnect-ExchangeOnline
         # the reason why we are not using Disconnect-ExchangeOnline is because it asks for a confirmation and $ConfirmPreference = 'None' does nothing, at least when running fron inside the script
         # inside a powershell window $ConfirmPreference = 'None' works as expected, but not when running within Trace or debugging in VSCode
-        $existingPSSession = Get-PSSession | Where-Object { $_.ConfigurationName -like "Microsoft.Exchange" -and $_.Name -like "ExchangeOnlineInternalSession*" }
+        $existingPSSession = Get-PSSession | Where-Object { ($_.ConfigurationName -like "Microsoft.Exchange" -and $_.Name -like "ExchangeOnlineInternalSession*") -or $_.Name -like 'SfBPowerShellSession*' }
 
         if ($existingPSSession.count -gt 0)
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -332,7 +332,7 @@ function Start-M365DSCConfigurationExtract
 
             $resourceExtractionStates[$msftResourceName] = 'NotIncluded'
             if (($null -ne $ComponentsToExtract -and
-                ($ComponentsToExtract -contains $resourceName -or $ComponentsToExtract -contains ("chck" + $resourceName))) -or
+                    ($ComponentsToExtract -contains $resourceName -or $ComponentsToExtract -contains ("chck" + $resourceName))) -or
                 $AllComponents -or ($null -ne $Workloads -and $Workloads -contains $currentWorkload) -or `
                 ($null -eq $ComponentsToExtract -and $null -eq $Workloads) -and `
                 ($ComponentsToExtractSpecified -or -not $ComponentsToSkip.Contains($resourceName)))
@@ -356,12 +356,12 @@ function Start-M365DSCConfigurationExtract
         {
             $shouldSkipBecauseOfFailedPlatforms = $false
             [array]$usedPlatforms = Get-ResourcePlatformUsage -Resource $resourceName -ResourceModuleFilePath $resource.FullName
-            foreach($platform in $usedPlatforms)
+            foreach ($platform in $usedPlatforms)
             {
                 # we will skip PnP if there was a problem connecting to a specific site
                 # it could be a permissions issue
                 # if it was a problem with connecting to the admin site, then we know that all else will fail as well so no need to continue
-                if($platform -eq 'PnP' -and $null -ne $Global:SPOAdminUrl -and $Global:SPOConnectionUrl -ne $Global:SPOAdminUrl)
+                if ($platform -eq 'PnP' -and $null -ne $Global:SPOAdminUrl -and $Global:SPOConnectionUrl -ne $Global:SPOAdminUrl)
                 {
                     continue
                 }
@@ -369,14 +369,14 @@ function Start-M365DSCConfigurationExtract
                 Write-Verbose "The isConnectionAvailable flag is $isAvailable for $platform"
                 $shouldSkipBecauseOfFailedPlatforms = $shouldSkipBecauseOfFailedPlatforms -or !$isAvailable
                 Write-Verbose "The shouldskip flag is $shouldSkipBecauseOfFailedPlatforms for $platform"
-                if(!$isAvailable -and !$platformSkipsNotified.Contains($platform))
+                if (!$isAvailable -and !$platformSkipsNotified.Contains($platform))
                 {
                     Write-Error "The [$platform] connection has failed and all of the related resources will be skipped to avoid unnecessary errors."
                     $platformSkipsNotified += $platform
                 }
             }
 
-            if($shouldSkipBecauseOfFailedPlatforms)
+            if ($shouldSkipBecauseOfFailedPlatforms)
             {
                 $resourceExtractionStates[$msftResourceName] = 'SkippedBecauseOfPreviousConnectionFailure'
                 Write-Verbose "Skipped [$resourceName] because of connection problems with the used MsCloudLogin platform"
@@ -394,7 +394,7 @@ function Start-M365DSCConfigurationExtract
             $CertPasswordExists = (Get-Command 'Export-TargetResource').Parameters.Keys.Contains("CertificatePassword")
 
             $parameters = @{}
-            if ($GlobalAdminExists-and -not [System.String]::IsNullOrEmpty($GlobalAdminAccount))
+            if ($GlobalAdminExists -and -not [System.String]::IsNullOrEmpty($GlobalAdminAccount))
             {
                 $parameters.Add("GlobalAdminAccount", $GlobalAdminAccount)
             }
@@ -444,14 +444,14 @@ function Start-M365DSCConfigurationExtract
                     [System.Management.Automation.Language.Token[]]$tokens = $null;
                     [System.Management.Automation.Language.ParseError[]]$parseErrors = $null;
                     [void][System.Management.Automation.Language.Parser]::ParseInput($exportString, [ref]$tokens, [ref]$parseErrors)
-                    if($parseErrors.Length -gt 0)
+                    if ($parseErrors.Length -gt 0)
                     {
                         Write-Error "The [$resourceName] resource encountered an error and will not be available in the extracted data"
                         Write-Verbose "The [$resourceName] had parse errors"
                         Write-Verbose "#######PARSE ERRORS START####################"
-                        foreach($parseError in $parseErrors)
+                        foreach ($parseError in $parseErrors)
                         {
-                           Write-Verbose $parseError
+                            Write-Verbose $parseError
                         }
                         Write-Verbose "#######PARSE INPUT WITH ERRORS START######################"
                         Write-Verbose $exportString
@@ -465,7 +465,7 @@ function Start-M365DSCConfigurationExtract
                     Write-Error $_
                 }
 
-                if($psParseErrorOccurred)
+                if ($psParseErrorOccurred)
                 {
                     $exportString = ""
                     $resourceExtractionStates[$msftResourceName] = 'PsParseError'
@@ -488,17 +488,17 @@ function Start-M365DSCConfigurationExtract
             $ex = $_.Exception
             $isMissingGrantError = $false
 
-            while($null -ne $ex -and $ex.GetType().FullName -ne "Microsoft.IdentityModel.Clients.ActiveDirectory.AdalServiceException")
+            while ($null -ne $ex -and $ex.GetType().FullName -ne "Microsoft.IdentityModel.Clients.ActiveDirectory.AdalServiceException")
             {
                 $ex = $ex.InnerException
             }
 
-            if($null -ne $ex -and $ex.ErrorCode -eq "invalid_grant" -and $null -ne $ex.ServiceErrorCodes -and $ex.ServiceErrorCodes.Contains("65001"))
+            if ($null -ne $ex -and $ex.ErrorCode -eq "invalid_grant" -and $null -ne $ex.ServiceErrorCodes -and $ex.ServiceErrorCodes.Contains("65001"))
             {
                 $isMissingGrantError = $true
             }
 
-            if($isMissingGrantError -and $currentWorkload -eq 'PP')
+            if ($isMissingGrantError -and $currentWorkload -eq 'PP')
             {
                 Write-Verbose "PowerApps service app permissions are not granted. The enteriprise application is most likely missing.`nVisit the PowerApps admin center to get it created and rerun the Trace Configuration Wizard"
 
@@ -509,13 +509,18 @@ function Start-M365DSCConfigurationExtract
             {
                 New-M365DSCLogEntry -Error $_ -Message $ResourceModule.Name -Source "[O365DSCReverse]$($ResourceModule.Name)"
             }
-		}
+        }
         finally
         {
             $WarningPreference = $DefaultWarningPreference;
             $VerbosePreference = $DefaultVerbosePreference;
-		}
+        }
     }
+
+
+    # dont' leave dangling remote sessions, there can only be a couple of them for EXO and SC
+    Remove-RemoteSessions
+
 
     # Close the Node and Configuration declarations
     $DSCContent += "    }`r`n"
@@ -550,7 +555,7 @@ function Start-M365DSCConfigurationExtract
     {
         if (-not [System.String]::IsNullOrEmpty($CertificatePassword))
         {
-            $certCreds =$Global:CredsRepo[0]
+            $certCreds = $Global:CredsRepo[0]
             $credsContent = ""
             $credsContent += "        " + (Resolve-Credentials $certCreds) + " = Get-Credential -Message `"Certificate Password`""
             $credsContent += "`r`n"
@@ -624,7 +629,7 @@ function Start-M365DSCConfigurationExtract
         $outputDSCFile = $OutputDSCPath + "M365TenantConfig.ps1"
     }
 
-     # this is to avoid problems with unicode charachters when executing the generated ps1 file
+    # this is to avoid problems with unicode charachters when executing the generated ps1 file
     $Utf8BomEncoding = New-Object System.Text.UTF8Encoding $True
     [System.IO.File]::WriteAllText($outputDSCFile, $DSCContent, $Utf8BomEncoding)
 
@@ -665,6 +670,62 @@ function Start-M365DSCConfigurationExtract
     }
 }
 
+
+function Remove-RemoteSessions
+{
+    $prevConfirmPreference = $ConfirmPreference
+    try
+    {
+        $ConfirmPreference = 'None'
+
+        # this will disconnect all of the Exhange but also all of the Security and Compliance sessions
+        #Disconnect-ExchangeOnline
+
+        # this code is basically copy pasted from Disconnect-ExchangeOnline
+        # the reason why we are not using Disconnect-ExchangeOnline is because it asks for a confirmation and $ConfirmPreference = 'None' does nothing, at least when running fron inside the script
+        # inside a powershell window $ConfirmPreference = 'None' works as expected, but not when running within Trace or debugging in VSCode
+        $existingPSSession = Get-PSSession | Where-Object { $_.ConfigurationName -like "Microsoft.Exchange" -and $_.Name -like "ExchangeOnlineInternalSession*" }
+
+        if ($existingPSSession.count -gt 0)
+        {
+            for ($index = 0; $index -lt $existingPSSession.count; $index++)
+            {
+                $session = $existingPSSession[$index]
+                Remove-PSSession -session $session
+
+                # Remove any previous modules loaded because of the current PSSession
+                if ($null -ne $session.PreviousModuleName)
+                {
+                    if ((Get-Module $session.PreviousModuleName).Count -ne 0)
+                    {
+                        Remove-Module -Name $session.PreviousModuleName -ErrorAction SilentlyContinue
+                    }
+
+                    $session.PreviousModuleName = $null
+                }
+
+                # Remove any leaked module in case of removal of broken session object
+                if ($null -ne $session.CurrentModuleName)
+                {
+                    if ((Get-Module $session.CurrentModuleName).Count -ne 0)
+                    {
+                        Remove-Module -Name $session.CurrentModuleName -ErrorAction SilentlyContinue
+                    }
+                }
+            }
+        }
+    }
+    catch
+    {
+        Write-Error "Error while disconnecting remote sessions"
+        Write-Error $_
+    }
+    finally
+    {
+        $ConfirmPreference = $prevConfirmPreference
+    }
+}
+
 function Check-PlatformAvailability
 {
     [CmdletBinding()]
@@ -695,10 +756,10 @@ function Get-ResourcePlatformUsage
     $matches = [Regex]::Matches($fileContent, '-Platform\s+''?(?<platform>\w+)''?', [ System.Text.RegularExpressions.RegexOptions]::IgnoreCase);
 
     $platforms = @()
-    foreach($match in $matches)
+    foreach ($match in $matches)
     {
         $platform = $match.Groups["platform"].Value
-        if($platforms.Contains($platform))
+        if ($platforms.Contains($platform))
         {
             continue
         }

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -229,11 +229,11 @@ function Get-AllTeamsCached
         }
         catch
         {
-            $missingGroup = ($null -ne $_.Exception -and $_.Exception.ErrorCode -eq 404) -or ($null -ne $_.Exception -and $null -ne $_.Exception.InnerException -and $_.Exception.InnerException.ErrorCode -eq 404);
+            $missingTeam = ($null -ne $_.Exception -and $_.Exception.ErrorCode -eq 404) -or ($null -ne $_.Exception -and $null -ne $_.Exception.InnerException -and $_.Exception.InnerException.ErrorCode -eq 404);
 
-            # write the output only if the group is not missing
+            # write the output only if the teams is not missing
             # if it's missing then it was probably deleted or something like that
-            if (!$missingGroup)
+            if (!$missingTeam)
             {
                 # we write it with verbose because if one team retrieval fails, they probably all will. No teams is hard to miss in the output data so the error should be evident
                 Write-Verbose $_

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1443,6 +1443,12 @@ function Start-DSCInitializedJob
 
     $msloginAssistentPath = (Get-Module MSCloudLoginAssistant).Path.Replace("psm1", "psd1")
     $setupJobScript = " Import-Module '$msloginAssistentPath' -Force | Out-Null;"
+
+    # an explicit import for the teams module because of some problems with missing .net types when used inside a PSJob
+    # this only occurs because they are accessed directly, not through a cmdlet from the teams module
+    $teamsModuleVersion = (Get-Module MicrosoftTeams).Version
+    $setupJobScript += " Import-Module MicrosoftTeams -RequiredVersion $teamsModuleVersion -Force | Out-Null;"
+
     if ($Global:appIdentityParams)
     {
         $entropyStr = [string]::Join(', ', $Global:appIdentityParams.TokenCacheEntropy)

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -157,12 +157,12 @@ function Get-TeamEnabledOffice365Groups
         $httpClient = [Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities]::GetClient("Bearer $accessToken", "Get-TeamTraceCustom")
 
         $requestUri = [Uri]::new("$endpoint/v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')&`$select=id,resourceProvisioningOptions,displayName,description,visibility,mailnickname,classification")
-            Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
-                $accessToken = Get-AppIdentityAccessToken $endpoint
-                $httpClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken");
-                $allTeams.AddRange([Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($httpClient, $requestUri)))
-                Write-Verbose "Retrieved all teams"
-            }
+        Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
+            $accessToken = Get-AppIdentityAccessToken $endpoint
+            $httpClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken");
+            $allTeams.AddRange([Microsoft.TeamsCmdlets.PowerShell.Custom.Utils.HttpUtilities].GetMethod("GetAll").MakeGenericMethod([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.Team]).Invoke($null, @($httpClient, $requestUri)))
+            Write-Verbose "Retrieved all teams"
+        }
 
         $allTeams = $allTeams | Where-Object {
             $_.ResourceProvisioningOptions.Contains("Team")
@@ -188,7 +188,7 @@ function Get-AllTeamsCached
         $ForceRefresh
     )
 
-    if($Global:O365TeamsCached -and !$ForceRefresh)
+    if ($Global:O365TeamsCached -and !$ForceRefresh)
     {
         return $Global:O365TeamsCached
     }
@@ -213,7 +213,7 @@ function Get-AllTeamsCached
             Invoke-WithTransientErrorExponentialRetry -ScriptBlock {
                 $accessToken = Get-AppIdentityAccessToken $endpoint
                 $singleTeamClient.DefaultRequestHeaders.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::Parse("Bearer $accessToken")
-                $groupId= $teamToRetrieve.GroupId
+                $groupId = $teamToRetrieve.GroupId
                 $singleTeamRequestUri = [Uri]::new("$endpoint/v1.0/teams/$groupId")
                 Write-Verbose "retrieving from $singleTeamRequestUri"
                 [Type[]]$types = @([System.Net.Http.HttpClient], [Uri])
@@ -226,6 +226,19 @@ function Get-AllTeamsCached
 
                 $allTeamSettings.Add([Microsoft.TeamsCmdlets.PowerShell.Custom.Model.TeamSettings]::new($team))
             }
+        }
+        catch
+        {
+            $missingGroup = ($null -ne $_.Exception -and $_.Exception.ErrorCode -eq 404) -or ($null -ne $_.Exception -and $null -ne $_.Exception.InnerException -and $_.Exception.InnerException.ErrorCode -eq 404);
+
+            # write the output only if the group is not missing
+            # if it's missing then it was probably deleted or something like that
+            if (!$missingGroup)
+            {
+                # we write it with verbose because if one team retrieval fails, they probably all will. No teams is hard to miss in the output data so the error should be evident
+                Write-Verbose $_
+            }
+
         }
         finally
         {
@@ -248,7 +261,7 @@ function Invoke-WithTransientErrorExponentialRetry
         $ScriptBlock
     )
 
-    if($null -eq $Global:O365DSCBackoffRandomizer)
+    if ($null -eq $Global:O365DSCBackoffRandomizer)
     {
         $Global:O365DSCBackoffRandomizer = [System.Random]::new()
     }
@@ -265,7 +278,7 @@ function Invoke-WithTransientErrorExponentialRetry
         }
         catch
         {
-            if($null -eq $_.Exception -or $null -eq $_.Exception.InnerException -or ($_.Exception.InnerException.ErrorCode -ne 429 -and $_.Exception.InnerException.ErrorCode -ne 503) -or $retryCount -eq 0)
+            if ($null -eq $_.Exception -or $null -eq $_.Exception.InnerException -or ($_.Exception.InnerException.ErrorCode -ne 429 -and $_.Exception.InnerException.ErrorCode -ne 503) -or $retryCount -eq 0)
             {
                 throw
             }
@@ -1088,7 +1101,7 @@ function Get-M365DSCTenantDomain
     if (!$CertificatePath)
     {
         $ConnectionMode = New-M365DSCConnection -Platform 'AzureAD' `
-                    -InboundParameters $PSBoundParameters
+            -InboundParameters $PSBoundParameters
         $tenantDetails = Get-AzureADTenantDetail
         $defaultDomain = $tenantDetails.VerifiedDomains | Where-Object -Filterscript { $_.Initial }
         return $defaultDomain.Name
@@ -1127,7 +1140,8 @@ function Get-M365DSCOrganization
         {
             $organization = $TenantId
             return $organization
-        }else
+        }
+        else
         {
             Throw "Tenant ID must be name of tenant not a GUID. Ex contoso.onmicrosoft.com"
         }
@@ -1173,25 +1187,25 @@ function New-M365DSCConnection
     # Case both authentication methods are attempted
     if ($null -ne $InboundParameters.GlobalAdminAccount -and `
         (-not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -or `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint)))
+                -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint)))
     {
         Write-Verbose -Message 'Both Authentication methods are attempted'
         throw "You can't specify both the GlobalAdminAccount and one of {TenantId, CertificateThumbprint}"
     }
     # Case no authentication method is specified
     elseif ($null -eq $InboundParameters.GlobalAdminAccount -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
+            [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
+            [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
+            [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
         Write-Verbose -Message "No Authentication method was provided"
         throw "You must specify either the GlobalAdminAccount or ApplicationId, TenantId and CertificateThumbprint parameters."
     }
     # Case only GlobalAdminAccount is specified
     elseif ($null -ne $InboundParameters.GlobalAdminAccount -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-        [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
+            [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
+            [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
+            [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
         Write-Verbose -Message "GlobalAdminAccount was specified. Connecting via User Principal"
         if ([System.String]::IsNullOrEmpty($Url))
@@ -1211,7 +1225,7 @@ function New-M365DSCConnection
     }
     # Case only the ApplicationID and Credentials parameters are specified
     elseif ($null -ne $InboundParameters.GlobalAdminAccount -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId))
+            -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId))
     {
         Write-Verbose -Message "GlobalAdminAccount and ApplicationId were specified. Connecting via Delegated Service Principal"
         if ([System.String]::IsNullOrEmpty($url))
@@ -1233,9 +1247,9 @@ function New-M365DSCConnection
     }
     # Case only the ServicePrincipal with Thumbprint parameters are specified
     elseif ($null -eq $InboundParameters.GlobalAdminAccount -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
+            -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
+            -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
+            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
         if ([System.String]::IsNullOrEmpty($url))
         {
@@ -1259,10 +1273,10 @@ function New-M365DSCConnection
     }
     # Case only the ServicePrincipal with Thumbprint parameters are specified
     elseif ($null -eq $InboundParameters.GlobalAdminAccount -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-        -not [System.String]::IsNullOrEmpty($InboundParameters.CertificatePath) -and `
-        $null -ne $InboundParameters.CertificatePassword)
+            -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
+            -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
+            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificatePath) -and `
+            $null -ne $InboundParameters.CertificatePassword)
     {
         if ([System.String]::IsNullOrEmpty($url))
         {
@@ -1340,7 +1354,7 @@ function Get-M365TenantName
     }
     Write-Verbose -Message "Connection to Azure AD is required to automatically determine SharePoint Online admin URL..."
     $ConnectionMode = New-M365DSCConnection -Platform 'AzureAD' `
-                -InboundParameters $PSBoundParameters
+        -InboundParameters $PSBoundParameters
     Write-Verbose -Message "Getting SharePoint Online admin URL..."
     $defaultDomain = Get-AzureADDomain | Where-Object { ($_.Name -like "*.onmicrosoft.com" -or $_.Name -like "*.onmicrosoft.de") -and $_.IsInitial -eq $true } # We don't use IsDefault here because the default could be a custom domain
 
@@ -1427,9 +1441,9 @@ function Start-DSCInitializedJob
         $ArgumentList
     )
 
-    $msloginAssistentPath = (Get-Module MSCloudLoginAssistant).Path.Replace("psm1","psd1")
+    $msloginAssistentPath = (Get-Module MSCloudLoginAssistant).Path.Replace("psm1", "psd1")
     $setupJobScript = " Import-Module '$msloginAssistentPath' -Force | Out-Null;"
-    if($Global:appIdentityParams)
+    if ($Global:appIdentityParams)
     {
         $entropyStr = [string]::Join(', ', $Global:appIdentityParams.TokenCacheEntropy)
         $setupJobScript += "[byte[]] `$tokenCacheEntropy = $entropyStr;"
@@ -1437,26 +1451,26 @@ function Start-DSCInitializedJob
     }
 
     # ReverseDSC is needed because most of the time the job will call something from it
-    $reverseDscModulePath = (Get-Module ReverseDSC).Path.Replace("psm1","psd1")
-    $setupJobScript +=  " Import-Module '$reverseDscModulePath' -Force | Out-Null;"
+    $reverseDscModulePath = (Get-Module ReverseDSC).Path.Replace("psm1", "psd1")
+    $setupJobScript += " Import-Module '$reverseDscModulePath' -Force | Out-Null;"
 
 
     $insertPosition = 0
-    if($ScriptBlock.Ast.BeginBlock)
+    if ($ScriptBlock.Ast.BeginBlock)
     {
         $insertPosition = $ScriptBlock.Ast.BeginBlock.Statements[0].Extent.StartOffset;
     }
-    elseif($ScriptBlock.Ast.ProcessBlock)
+    elseif ($ScriptBlock.Ast.ProcessBlock)
     {
         $insertPosition = $ScriptBlock.Ast.ProcessBlock.Statements[0].Extent.StartOffset;
     }
-    elseif($ScriptBlock.Ast.EndBlock)
+    elseif ($ScriptBlock.Ast.EndBlock)
     {
         $insertPosition = $ScriptBlock.Ast.EndBlock.Statements[0].Extent.StartOffset;
     }
     $insertPosition = $insertPosition - $ScriptBlock.StartPosition.Start
     $strScriptContent = $ScriptBlock.ToString();
-    $strScriptContent = $strScriptContent.Insert($insertPosition - 1, $setupJobScript +"`n")
+    $strScriptContent = $strScriptContent.Insert($insertPosition - 1, $setupJobScript + "`n")
     $newScriptBlock = [ScriptBlock]::Create($strScriptContent)
     Start-Job -Name $Name -ScriptBlock $newScriptBlock  -ArgumentList $ArgumentList
 }
@@ -1637,13 +1651,13 @@ function Get-AllSPOPackages
     )
 
     $ConnectionMode = New-M365DSCConnection -Platform 'PnP' `
-                -InboundParameters $PSBoundParameters
+        -InboundParameters $PSBoundParameters
 
     $tenantAppCatalogUrl = Get-PnPTenantAppCatalogUrl
 
     $ConnectionMode = New-M365DSCConnection -Platform 'PnP' `
-                -InboundParameters $PSBoundParameters `
-                -Url $tenantAppCatalogUrl
+        -InboundParameters $PSBoundParameters `
+        -Url $tenantAppCatalogUrl
 
     $filesToDownload = @()
 
@@ -2345,10 +2359,11 @@ function Get-M365DSCExportContentForResource
         }
     }
 
-    foreach ($dscProp in $PropertiesWithDscBlock) {
+    foreach ($dscProp in $PropertiesWithDscBlock)
+    {
         $isCimArray = $null -ne $PropertiesCimArrays -and $PropertiesCimArrays.Contains($dscProp)
         $partialContent = Convert-DSCStringParamToVariable -DSCBlock $partialContent `
-        -ParameterName $dscProp -IsCimArray $isCimArray
+            -ParameterName $dscProp -IsCimArray $isCimArray
     }
 
     if ($partialContent.ToLower().IndexOf($OrganizationName.ToLower()) -gt 0)
@@ -2418,8 +2433,9 @@ function Execute-CSOMQueryRetry
    Load-CSOMProperties -object $web -propertyNames @("Title", "Url", "AllProperties") -executeQuery
    $web | select Title, Url, AllProperties
 #>
-function Load-CSOMProperties {
-    [CmdletBinding(DefaultParameterSetName='ClientObject')]
+function Load-CSOMProperties
+{
+    [CmdletBinding(DefaultParameterSetName = 'ClientObject')]
     param (
         # The Microsoft.SharePoint.Client.ClientObject to populate.
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0, ParameterSetName = "ClientObject")]
@@ -2453,13 +2469,20 @@ function Load-CSOMProperties {
         $executeQuery
     )
 
-    begin { }
-    process {
-        if ($PsCmdlet.ParameterSetName -eq "ClientObject") {
+    begin
+    {
+    }
+    process
+    {
+        if ($PsCmdlet.ParameterSetName -eq "ClientObject")
+        {
             $type = $object.GetType()
-        } else {
+        }
+        else
+        {
             $type = $collectionObject.GetType()
-            if ($collectionObject -is [Microsoft.SharePoint.Client.ClientObjectCollection]) {
+            if ($collectionObject -is [Microsoft.SharePoint.Client.ClientObjectCollection])
+            {
                 $type = $collectionObject.GetType().BaseType.GenericTypeArguments[0]
             }
         }
@@ -2470,28 +2493,38 @@ function Load-CSOMProperties {
         $lambdaMethodGeneric = Invoke-Expression "`$lambdaMethod.MakeGenericMethod([System.Func``2[$($type.FullName),System.Object]])"
         $expressions = @()
 
-        foreach ($propertyName in $propertyNames) {
+        foreach ($propertyName in $propertyNames)
+        {
             $param1 = [System.Linq.Expressions.Expression]::Parameter($type, "p")
-            try {
+            try
+            {
                 $name1 = [System.Linq.Expressions.Expression]::Property($param1, $propertyName)
-            } catch {
+            }
+            catch
+            {
                 Write-Error "Instance property '$propertyName' is not defined for type $type"
                 return
             }
             $body1 = [System.Linq.Expressions.Expression]::Convert($name1, [System.Object])
             $expression1 = $lambdaMethodGeneric.Invoke($null, [System.Object[]] @($body1, [System.Linq.Expressions.ParameterExpression[]] @($param1)))
 
-            if ($collectionObject -ne $null) {
+            if ($collectionObject -ne $null)
+            {
                 $expression1 = [System.Linq.Expressions.Expression]::Quote($expression1)
             }
             $expressions += @($expression1)
         }
 
 
-        if ($PsCmdlet.ParameterSetName -eq "ClientObject") {
+        if ($PsCmdlet.ParameterSetName -eq "ClientObject")
+        {
             $object.Context.Load($object, $expressions)
-            if ($executeQuery) { $object.Context.ExecuteQuery() }
-        } else {
+            if ($executeQuery)
+            { $object.Context.ExecuteQuery()
+            }
+        }
+        else
+        {
             $newArrayInitParam1 = Invoke-Expression "[System.Linq.Expressions.Expression``1[System.Func````2[$($type.FullName),System.Object]]]"
             $newArrayInit = [System.Linq.Expressions.Expression]::NewArrayInit($newArrayInitParam1, $expressions)
 
@@ -2508,10 +2541,14 @@ function Load-CSOMProperties {
             $expression2 = $lambdaMethodGeneric2.Invoke($null, @($callMethod, [System.Linq.Expressions.ParameterExpression[]] @($collectionParam)))
 
             $parentObject.Context.Load($parentObject, $expression2)
-            if ($executeQuery) { $parentObject.Context.ExecuteQuery() }
+            if ($executeQuery)
+            { $parentObject.Context.ExecuteQuery()
+            }
         }
     }
-    end { }
+    end
+    {
+    }
 }
 
 function Get-DSCPSTokenValue
@@ -2528,26 +2565,27 @@ function Get-DSCPSTokenValue
         $AllowSpecialCharachters
     )
 
-    if($null -eq $Value)
+    if ($null -eq $Value)
     {
         $Value = ""
     }
 
-    if(!($Value -is [string])) {
+    if (!($Value -is [string]))
+    {
         $Value = $Value.ToString()
     }
 
-    $sb =  [System.Text.StringBuilder]::new()
+    $sb = [System.Text.StringBuilder]::new()
 
     [void]$sb.Append("`"")
 
-    if(!$AllowSpecialCharachters)
+    if (!$AllowSpecialCharachters)
     {
-        foreach($char in [char[]]$Value)
+        foreach ($char in [char[]]$Value)
         {
-            if($char -eq '"' -or $char -eq [char]0x201C -or $char -eq [char]0x201D -or $char -eq [char]0x201E -or $char -eq '$')
+            if ($char -eq '"' -or $char -eq [char]0x201C -or $char -eq [char]0x201D -or $char -eq [char]0x201E -or $char -eq '$')
             {
-               [void]$sb.Append('`')
+                [void]$sb.Append('`')
             }
             [void]$sb.Append($char)
         }
@@ -2570,7 +2608,7 @@ class EmbbededResourceInfo
 
 function Get-DSCBlockEx
 {
-<#
+    <#
 .SYNOPSIS
 Generate the DSC string representing the resource's instance.
 
@@ -2614,7 +2652,7 @@ Hashtable that contains the list of Key properties and their values.
     $Sorted = $Params.GetEnumerator() | Sort-Object -Property Name
     $NewParams = [Ordered]@{}
 
-    foreach($entry in $Sorted)
+    foreach ($entry in $Sorted)
     {
         $NewParams.Add($entry.Key, $entry.Value)
     }
@@ -2650,13 +2688,13 @@ Hashtable that contains the list of Key properties and their values.
 
         $value = $null
         $propName = $_
-        if($null -ne $PropertiesWithEmbeddedResources -and $PropertiesWithEmbeddedResources.Length -gt 0 -and ($idx = [System.Array]::FindIndex($PropertiesWithEmbeddedResources, [Predicate[EmbbededResourceInfo]]{$args[0].PropertyName -eq $propName })) -ge 0)
+        if ($null -ne $PropertiesWithEmbeddedResources -and $PropertiesWithEmbeddedResources.Length -gt 0 -and ($idx = [System.Array]::FindIndex($PropertiesWithEmbeddedResources, [Predicate[EmbbededResourceInfo]] { $args[0].PropertyName -eq $propName })) -ge 0)
         {
             $meta = $PropertiesWithEmbeddedResources[$idx]
-            if($paramType -eq "ArrayList" -or $paramType -eq "List``1" -or $paramType -eq "Hashtable[]")
+            if ($paramType -eq "ArrayList" -or $paramType -eq "List``1" -or $paramType -eq "Hashtable[]")
             {
                 $value = "@("
-                foreach($obj in $NewParams[$_])
+                foreach ($obj in $NewParams[$_])
                 {
                     $value += "                  $($meta.ResourceName)`r`n            {`r`n"
                     $value += Get-DSCBlockEx -ModulePath $ModulePath -Params $obj -IndentValue 4
@@ -2728,13 +2766,13 @@ Hashtable that contains the list of Key properties and their values.
             if ($hash -and !$hash.ToString().StartsWith("`$ConfigurationData."))
             {
                 $value = "@("
-                $hash| ForEach-Object {
+                $hash | ForEach-Object {
                     $escapedValue = Get-DSCPSTokenValue -Value $_ -AllowSpecialCharachters $AllowSpecialCharachtersInValues
-                    $value += $escapedValue +","
+                    $value += $escapedValue + ","
                 }
-                if($value.Length -gt 2)
+                if ($value.Length -gt 2)
                 {
-                    $value = $value.Substring(0,$value.Length -1)
+                    $value = $value.Substring(0, $value.Length - 1)
                 }
                 $value += ")"
             }
@@ -2756,12 +2794,12 @@ Hashtable that contains the list of Key properties and their values.
             if ($hash)
             {
                 $value = "@("
-                $hash| ForEach-Object {
+                $hash | ForEach-Object {
                     $value += $_.ToString() + ","
                 }
-                if($value.Length -gt 2)
+                if ($value.Length -gt 2)
                 {
-                    $value = $value.Substring(0,$value.Length -1)
+                    $value = $value.Substring(0, $value.Length - 1)
                 }
                 $value += ")"
             }
@@ -2784,20 +2822,20 @@ Hashtable that contains the list of Key properties and their values.
             if ($array.Length -gt 0 -and ($array[0].GetType().Name -eq "String" -and $paramType -ne "Microsoft.Management.Infrastructure.CimInstance[]"))
             {
                 $value = "@("
-                $hash| ForEach-Object {
+                $hash | ForEach-Object {
                     $escapedItemValue = Get-DSCPSTokenValue -Value $_ -AllowSpecialCharachters $AllowSpecialCharachtersInValues
-                    $value +=  $escapedItemValue + ","
+                    $value += $escapedItemValue + ","
                 }
-                if($value.Length -gt 2)
+                if ($value.Length -gt 2)
                 {
-                    $value = $value.Substring(0,$value.Length -1)
+                    $value = $value.Substring(0, $value.Length - 1)
                 }
                 $value += ")"
             }
             else
             {
                 $value = "@("
-                $array | ForEach-Object{
+                $array | ForEach-Object {
                     $value += $_
                 }
                 $value += ")"
@@ -2815,7 +2853,7 @@ Hashtable that contains the list of Key properties and their values.
             }
             else
             {
-                if($NewParams[$_].GetType().BaseType.Name -eq "Enum")
+                if ($NewParams[$_].GetType().BaseType.Name -eq "Enum")
                 {
                     $value = "`"" + $NewParams.Item($_) + "`""
                 }
@@ -2834,7 +2872,7 @@ Hashtable that contains the list of Key properties and their values.
         {
             $additionalSpaces += " "
         }
-        $dscBlock += [string]::new(' ', 12 + $IndentValue) + $_  + $additionalSpaces + " = " + $value + ";`r`n"
+        $dscBlock += [string]::new(' ', 12 + $IndentValue) + $_ + $additionalSpaces + " = " + $value + ";`r`n"
     }
 
     return $dscBlock
@@ -2859,13 +2897,13 @@ function Get-M365DSCComponentsForAuthenticationType
 
         # Case - Resource only supports AppID & GlobalAdmin
         if ($AuthenticationMethod.Contains("Application") -and `
-            $AuthenticationMethod.Contains("Credentials") -and `
-           ($parameters.Contains("ApplicationId") -and `
-            $parameters.Contains("GlobalAdminAccount") -and `
-            -not $parameters.Contains('CertificateThumbprint') -and `
-            -not $parameters.Contains('CertificatePath') -and `
-            -not $parameters.Contains('CertificatePassword') -and `
-            -not $parameters.Contains('TenantId')))
+                $AuthenticationMethod.Contains("Credentials") -and `
+            ($parameters.Contains("ApplicationId") -and `
+                    $parameters.Contains("GlobalAdminAccount") -and `
+                    -not $parameters.Contains('CertificateThumbprint') -and `
+                    -not $parameters.Contains('CertificatePath') -and `
+                    -not $parameters.Contains('CertificatePassword') -and `
+                    -not $parameters.Contains('TenantId')))
         {
             $Components += $resource.Name.Replace("MSFT_", "").Replace(".psm1", "")
         }
@@ -2873,16 +2911,16 @@ function Get-M365DSCComponentsForAuthenticationType
         #Case - Resource certificate info and TenantId
         elseif ($AuthenticationMethod.Contains("Certificate") -and `
             ($parameters.Contains('CertificateThumbprint') -or `
-            $parameters.Contains('CertificatePath') -or `
-            $parameters.Contains('CertificatePassword')) -and `
-            $parameters.Contains('TenantId'))
+                    $parameters.Contains('CertificatePath') -or `
+                    $parameters.Contains('CertificatePassword')) -and `
+                $parameters.Contains('TenantId'))
         {
             $Components += $resource.Name.Replace("MSFT_", "").Replace(".psm1", "")
         }
 
         # Case - Resource contains GlobalAdminAccount
         elseif ($AuthenticationMethod.Contains("Credentials") -and `
-            $parameters.Contains('GlobalAdminAccount'))
+                $parameters.Contains('GlobalAdminAccount'))
         {
             $Components += $resource.Name.Replace("MSFT_", "").Replace(".psm1", "")
         }


### PR DESCRIPTION
- handled some resource loading same as I did for some of them in the past, injecting the value instead of going to M365 again. This is to lessen the load a bit on the Remote PowerShell and potentially to speed up the snapshot
- TeamsUpgradePolicy has been rewritten, additional properties
- added `Remove-RemoteSessions` that clears all remote sessions after a snapshot. 
- ignoring missing group exceptions. Not sure why the team could not be found, but it certainly does not mean that everything must stop 
- fixed an issue with Start-DSCInitializedJob, the TeamsUser, TeamsChannel resources failed because there were no team module types available, The fix was to preload the MicrosoftTeams module

Additional fixes will be in a separate PR.