### PR TITLE
Gcc high support b/large env support

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -538,15 +538,6 @@ function Start-M365DSCConfigurationExtract
     Write-Host "}"
     #endregion
 
-    if (-not [System.String]::IsNullOrEmpty($FileName))
-    {
-        $outputDSCFile = $OutputDSCPath + $FileName
-    }
-    else
-    {
-        $outputDSCFile = $OutputDSCPath + "M365TenantConfig.ps1"
-    }
-
     Write-ExtractionStates -OutputDSCPath $OutputDSCPath -ResourceExtractionStates $resourceExtractionStates -ResourceTimeTotalTaken $resourceTimeTotalTaken
 
     if (!$AzureAutomation)


### PR DESCRIPTION
This PR brings support for configuration files per resource instead of in just one file. the goal is to alleviate the issue with the buffer size problem for large environments. It may still happen, but it should not bring down the whole snapshot.