### PR TITLE
Bug/small diff fixes

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -27,7 +27,7 @@ function Get-TargetResource
 
         [Parameter()]
         [Boolean]
-        $EnableSafeDocs  = $false,
+        $EnableSafeDocs = $false,
 
         [Parameter()]
         [Boolean]
@@ -105,20 +105,20 @@ function Get-TargetResource
         else
         {
             $enableSafeLinksForO365Clients = $AtpPolicyForO365.EnableSafeLinksForO365Clients
-            if($null -eq $enableSafeLinksForO365Clients)
+            if ($null -eq $enableSafeLinksForO365Clients)
             {
                 $enableSafeLinksForO365Clients = $AtpPolicyForO365.EnableSafeLinksForClients
             }
             $result = @{
-                IsSingleInstance                = "Yes"
-                Identity                        = $AtpPolicyForO365.Identity
-                AllowClickThrough               = $AtpPolicyForO365.AllowClickThrough
-                BlockUrls                       = $AtpPolicyForO365.BlockUrls
-                EnableATPForSPOTeamsODB         = $AtpPolicyForO365.EnableATPForSPOTeamsODB
-                EnableSafeDocs                  = $AtpPolicyForO365.EnableSafeDocs
-                EnableSafeLinksForO365Clients   = $AtpPolicyForO365.EnableSafeLinksForO365Clients
-                TrackClicks                     = $AtpPolicyForO365.TrackClicks
-                Ensure                          = 'Present'
+                IsSingleInstance              = "Yes"
+                Identity                      = $AtpPolicyForO365.Identity
+                AllowClickThrough             = $AtpPolicyForO365.AllowClickThrough
+                BlockUrls                     = $AtpPolicyForO365.BlockUrls
+                EnableATPForSPOTeamsODB       = $AtpPolicyForO365.EnableATPForSPOTeamsODB
+                EnableSafeDocs                = $AtpPolicyForO365.EnableSafeDocs
+                EnableSafeLinksForO365Clients = $enableSafeLinksForO365Clients
+                TrackClicks                   = $AtpPolicyForO365.TrackClicks
+                Ensure                        = 'Present'
             }
 
             Write-Verbose -Message "Found AtpPolicyForO365 $($Identity)"
@@ -180,7 +180,7 @@ function Set-TargetResource
 
         [Parameter()]
         [Boolean]
-        $EnableSafeDocs  = $false,
+        $EnableSafeDocs = $false,
 
         [Parameter()]
         [Boolean]
@@ -276,7 +276,7 @@ function Test-TargetResource
 
         [Parameter()]
         [Boolean]
-        $EnableSafeDocs  = $false,
+        $EnableSafeDocs = $false,
 
         [Parameter()]
         [Boolean]
@@ -403,7 +403,7 @@ function Export-TargetResource
             }
             else
             {
-                Write-Host "`r`n" -NoNewLine
+                Write-Host "`r`n" -NoNewline
             }
             $i = 1
             foreach ($atpPolicy in $ATPPolicies)
@@ -418,7 +418,7 @@ function Export-TargetResource
                     CertificatePassword   = $CertificatePassword
                     CertificatePath       = $CertificatePath
                 }
-                Write-Host "    |---[$i/$($ATPPolicies.Length)] $($atpPolicy.Identiy)" -NoNewLine
+                Write-Host "    |---[$i/$($ATPPolicies.Length)] $($atpPolicy.Identiy)" -NoNewline
                 $Results = Get-TargetResource @Params
                 if ($Results.Ensure -eq "Present")
                 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -104,6 +104,11 @@ function Get-TargetResource
         }
         else
         {
+            $enableSafeLinksForO365Clients = $AtpPolicyForO365.EnableSafeLinksForO365Clients
+            if($null -eq $enableSafeLinksForO365Clients)
+            {
+                $enableSafeLinksForO365Clients = $AtpPolicyForO365.EnableSafeLinksForClients
+            }
             $result = @{
                 IsSingleInstance                = "Yes"
                 Identity                        = $AtpPolicyForO365.Identity

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -256,7 +256,10 @@ function Get-TargetResource
             }
             if ($null -ne $label.EncryptionRightsDefinitions)
             {
-                $EncryptionRightsDefinitionsValue = Convert-EncryptionRightDefinition -RightsDefinition $label.EncryptionRightsDefinitions
+                $EncryptionRightsDefinitionsValue = $label.EncryptionRightsDefinitions
+
+                # SysKit Update: we prefer the older format
+                #$EncryptionRightsDefinitionsValue = Convert-EncryptionRightDefinition -RightsDefinition $label.EncryptionRightsDefinitions
             }
             Write-Verbose "Found existing Sensitivity Label $($Name)"
             $result = @{
@@ -300,6 +303,7 @@ function Get-TargetResource
                 EncryptionProtectionType                       = $label.EncryptionProtectionType
                 EncryptionRightsDefinitions                    = $EncryptionRightsDefinitionsValue
                 EncryptionRightsUrl                            = $label.EncryptionRightsUrl
+                EncryptionTemplateId                           = $label.EncryptionTemplateId
                 SiteAndGroupProtectionAllowAccessToGuestUsers  = $label.SiteAndGroupProtectionAllowAccessToGuestUsers
                 SiteAndGroupProtectionAllowEmailFromGuestUsers = $label.SiteAndGroupProtectionAllowEmailFromGuestUsers
                 SiteAndGroupProtectionAllowFullAccess          = $label.SiteAndGroupProtectionAllowFullAccess

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.schema.mof
@@ -52,6 +52,7 @@ class MSFT_SCSensitivityLabel : OMI_BaseResource
     [Write, Description("The EncryptionProtectionType parameter specifies the protection type for encryption."), ValueMap{"Template","RemoveProtection","UserDefined"}, Values{"Template","RemoveProtection","UserDefined"}] String EncryptionProtectionType;
     [Write, Description("The EncryptionRightsDefinitions parameter specifies the rights users have when accessing protected. This parameter uses the syntax Identity1:Rights1,Rights2;Identity2:Rights3,Rights4. For example, john@contoso.com:VIEW,EDIT;microsoft.com:VIEW.")] String EncryptionRightsDefinitions;
     [Write, Description("The EncryptionRightsUrl parameter specifies the URL for hold your own key (HYOK) protection.")] String EncryptionRightsUrl;
+    [Write, Description("The EncryptionTemplateId parameter links an existing Azure RMS template to a new label.")] String EncryptionTemplateId;
     [Write, Description("The SiteAndGroupProtectionAllowAccessToGuestUsers parameter enables or disables access to guest users.")] Boolean SiteAndGroupProtectionAllowAccessToGuestUsers;
     [Write, Description("The SiteAndGroupProtectionAllowEmailFromGuestUsers parameter enables or disables email from guest users.")] Boolean SiteAndGroupProtectionAllowEmailFromGuestUsers;
     [Write, Description("The SiteAndGroupProtectionAllowFullAccess parameter enables or disables full access.")] Boolean SiteAndGroupProtectionAllowFullAccess;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -148,6 +148,7 @@ function Get-TargetResource
             SearchResolveExactEmailOrUPN                  = $SPOTenantSettings.SearchResolveExactEmailOrUPN
             OfficeClientADALDisabled                      = $SPOTenantSettings.OfficeClientADALDisabled
             LegacyAuthProtocolsEnabled                    = $SPOTenantSettings.LegacyAuthProtocolsEnabled
+            RequireAcceptingAccountMatchInvitedAccount    = $SPOTenantSettings.RequireAcceptingAccountMatchInvitedAccount
             SignInAccelerationDomain                      = $SPOTenantSettings.SignInAccelerationDomain
             UsePersistentCookiesForExplorerView           = $SPOTenantSettings.UsePersistentCookiesForExplorerView
             UserVoiceForFeedbackEnabled                   = $SPOTenantSettings.UserVoiceForFeedbackEnabled

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
@@ -540,18 +540,20 @@ function Get-M365DSCNormalizationRules
     }
 
     $result = @()
+    $allRules = Get-CsVoiceNormalizationRule
     foreach ($rule in $Rules)
     {
         $ruleName = $rule.Name.Replace("Tag:", "")
+        $ruleObject = $allRules | Where-Object -FilterScript { $_.Name -eq $ruleName }
         $currentRule = @{
             Identity            = $ruleName
-            Priority            = $rule.Priority
-            Description         = $rule.Description
-            Pattern             = $rule.Pattern
-            Translation         = $rule.Translation
-            IsInternalExtension = $rule.IsInternalExtension
+            Priority            = $ruleObject.Priority
+            Description         = $ruleObject.Description
+            Pattern             = $ruleObject.Pattern
+            Translation         = $ruleObject.Translation
+            IsInternalExtension = $ruleObject.IsInternalExtension
         }
-        if ([System.String]::IsNullOrEmpty($rule.Priority))
+        if ([System.String]::IsNullOrEmpty($ruleObject.Priority))
         {
             $currentRule.Remove("Priority") | Out-Null
         }


### PR DESCRIPTION
- EXO atp policy fallback to old deprecated value, just in case. From my understanding it depends on the environment if the newer non-deprecated version is available
- Normalization rules do not have all the values(priority) when accessed through the dial plan object. Reverted to an older version of the logic
- minor change on sensitivity labels and tenantsettings