### PR TITLE
updated MicrosoftTeams module because of Sfb auth and fixed issues wi…

### DIFF
--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -91,7 +91,7 @@
         #},
         @{
             ModuleName      = "MicrosoftTeams"
-            RequiredVersion = "1.1.6"
+            RequiredVersion = "2.3.1"
         },
         # In SysKit Trace, we provide our own version of MSCloudLoginAssistant
         # so no need to list it as a dependency
@@ -142,16 +142,16 @@
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @('Assert-M365DSCBlueprint',
-                          'Assert-M365DSCTemplate',
-                          'Compare-M365DSCConfigurations',
-                          'Export-M365DSCConfiguration',
+        'Assert-M365DSCTemplate',
+        'Compare-M365DSCConfigurations',
+        'Export-M365DSCConfiguration',
         'Export-M365DSCDiagnosticData',
-                          'New-M365DSCDeltaReport',
-                          'New-M365DSCReportFromConfiguration',
+        'New-M365DSCDeltaReport',
+        'New-M365DSCReportFromConfiguration',
         'New-M365DSCStubFiles',
-                          'Set-M365DSCAgentCertificateConfiguration',
-                          'Test-M365DSCAgent',
-                          'Test-M365DSCDependenciesForNewVersions')
+        'Set-M365DSCAgentCertificateConfiguration',
+        'Test-M365DSCAgent',
+        'Test-M365DSCDependenciesForNewVersions')
 
     # Variables to export from this module
     # VariablesToExport = @()


### PR DESCRIPTION
Updated the MicrosoftTeams module to support the new SkypeForBusiness remote PowerShell connections inside MsCloudLoginAssistant. Had an issue with loading teams since they massively changed the MicrosoftTeams module and we are using some internal classes to support loading teams with handling throttling. From what I've seen in the new MicrosoftTeams module codebase, it's still prone to throttling so I left our logic as is and simply updated to work with the new module.

 Fortunately for the "hacks" that we have to overcome the throttling problems, it was not an issue to fix.